### PR TITLE
If the name column is called 'name', refer to it as 'name', not '#name'.

### DIFF
--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -221,7 +221,7 @@ def find_overlapping_genes(row,df_genes):
         elif '#name' in row_g.keys():
             genes_overlapping.append( '%s' % (row_g['#name']))
         elif 'name' in row_g.keys():
-            genes_overlapping.append( '%s' % (row_g['#name']))
+            genes_overlapping.append( '%s' % (row_g['name']))
         else:
             genes_overlapping.append( '%s' % (row_g[0]))
 


### PR DESCRIPTION
Fixes the following error at the end of the process:
`KeyError: ('#name', u'occurred at index TaFielderBADH2-1a')`