### PR TITLE
Allow for duplicate amplicons when sgRNA differs

### DIFF
--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -632,9 +632,18 @@ def main():
             df_template.sgRNA=df_template.sgRNA.apply(CRISPRessoShared.capitalize_sequence)
             df_template.Coding_sequence=df_template.Coding_sequence.apply(CRISPRessoShared.capitalize_sequence)
 
-            if not len(df_template.Amplicon_Sequence.unique())==df_template.shape[0]:
-                duplicated_entries = df_template.Amplicon_Sequence[df_template.Amplicon_Sequence.duplicated()]
-                raise Exception('The amplicon sequences must be distinct! (Duplicated entries: ' + str(duplicated_entries.values) + ')')
+            if (df_template[["Amplicon_Sequence", "sgRNA"]].value_counts().values > 1).any():
+                duplicated_entries = df_template.loc[
+                    df_template[
+                        ["Amplicon_Sequence", "sgRNA"]
+                    ].duplicated(keep=False),
+                    :
+                ]
+                raise Exception(
+                    'The amplicon sequences and sgRNA must be distinct! (Duplicated entries: {0})'.format(
+                        duplicated_entries.values,
+                    ),
+                )
 
             if not len(df_template.Name.unique())==df_template.shape[0]:
                 duplicated_entries = df_template.Name[df_template.Name.duplicated()]


### PR DESCRIPTION
This is in response to a user's request. It now checks both the amplicons and sgRNAs and will only throw the exception when both the amplicon and sgRNA are duplicated.

Some thoughts/questions @kclem :

- Do we care if sgRNAs are duplicated? I don't believe that matters.
- Do we want to add a parameter to make this behavior allowable?
- This has been tested to the extent that an Exception will be thrown when the amplicon and sgRNA are the duplicated (and a duplicated amplicon with different sgRNA will no longer throw the Exception). As for the downstream results of running a duplicated amplicon, they remain untested. 