### PR TITLE
Quote folder and file names passed to flash

### DIFF
--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -2179,7 +2179,7 @@ def main():
             output_prefix = "out"
             if clean_file_prefix != "":
                 output_prefix = clean_file_prefix + "out"
-            cmd='%s "%s" "%s" --min-overlap %d --max-overlap %d --allow-outies -z -d %s -o %s >>%s 2>&1' %\
+            cmd='%s "%s" "%s" --min-overlap %d --max-overlap %d --allow-outies -z -d "%s" -o "%s" >>"%s" 2>&1' %\
             (args.flash_command,
                  output_forward_paired_filename,
                  output_reverse_paired_filename,


### PR DESCRIPTION
For a paired-end run, when the full path of the `output_folder` has a space in it, the `flash` command (hence the whole CRISPResso run) fails due to unescaped/unquoted file/folder names.

This fails (since `output_folder` is `foo with space`):

```bash
$ CRISPResso --fastq_r1 nhej.r1.fastq.gz --fastq_r2 nhej.r2.fastq.gz --amplicon_seq AATGTCCCCCAATGGGAAGTTCATCTGGCACTGCCCACAGGTGAGGAGGTCATGATCCCCTTCTGGAGCTCCCAACGGGCCGTGGTCTGGTTCATCATCTGTAAGAATGGCTTCAAGAGGCTCGGCTGTGGTT -n nhej --output_folder "foo with space"

                               ~~~CRISPResso 2~~~
        -Analysis of genome editing outcomes from deep sequencing data-

                                        _
                                       '  )
                                       .-'
                                      (____
                                   C)|     \
                                     \     /
                                      \___/

                          [CRISPResso version 2.2.11]
[Note that starting in version 2.1.0 insertion quantification has been changed
to only include insertions completely contained by the quantification window.
To use the legacy quantification method (i.e. include insertions directly adjacent
to the quantification window) please use the parameter --use_legacy_insertion_quantification]
                 [For support contact kclement@mgh.harvard.edu]

INFO  @ Tue, 25 Oct 2022 15:06:59:
	 Creating Folder /Users/arman/Desktop/crispresso_test/run/foo with space/CRISPResso_on_nhej

INFO  @ Tue, 25 Oct 2022 15:06:59:
	 Estimating average read length...

INFO  @ Tue, 25 Oct 2022 15:06:59:
	 Merging paired sequences with Flash...

INFO  @ Tue, 25 Oct 2022 15:06:59:
	 Running FLASH command: flash "nhej.r1.fastq.gz" "nhej.r2.fastq.gz" --min-overlap 10 --max-overlap 100 --allow-outies -z -d /Users/arman/Desktop/crispresso_test/run/foo with space/CRISPResso_on_nhej -o out >>/Users/arman/Desktop/crispresso_test/run/foo with space/CRISPResso_on_nhej/CRISPResso_RUNNING_LOG.txt 2>&1

CRITICAL @ Tue, 25 Oct 2022 15:06:59:
	 Merging error, please check your input.

ERROR: Flash failed to run, please check the log file.

```

but this doesn't fail (`output_folder` is set to `foo`):

```bash
$ CRISPResso --fastq_r1 nhej.r1.fastq.gz --fastq_r2 nhej.r2.fastq.gz --amplicon_seq AATGTCCCCCAATGGGAAGTTCATCTGGCACTGCCCACAGGTGAGGAGGTCATGATCCCCTTCTGGAGCTCCCAACGGGCCGTGGTCTGGTTCATCATCTGTAAGAATGGCTTCAAGAGGCTCGGCTGTGGTT -n nhej --output_folder foo

                               ~~~CRISPResso 2~~~
        -Analysis of genome editing outcomes from deep sequencing data-

                                        _
                                       '  )
                                       .-'
                                      (____
                                   C)|     \
                                     \     /
                                      \___/

                          [CRISPResso version 2.2.11]
[Note that starting in version 2.1.0 insertion quantification has been changed
to only include insertions completely contained by the quantification window.
To use the legacy quantification method (i.e. include insertions directly adjacent
to the quantification window) please use the parameter --use_legacy_insertion_quantification]
                 [For support contact kclement@mgh.harvard.edu]

INFO  @ Tue, 25 Oct 2022 15:08:38:
	 Creating Folder /Users/arman/Desktop/crispresso_test/run/foo/CRISPResso_on_nhej

INFO  @ Tue, 25 Oct 2022 15:08:38:
	 Estimating average read length...

INFO  @ Tue, 25 Oct 2022 15:08:39:
	 Merging paired sequences with Flash...

INFO  @ Tue, 25 Oct 2022 15:08:39:
	 Running FLASH command: flash "nhej.r1.fastq.gz" "nhej.r2.fastq.gz" --min-overlap 10 --max-overlap 100 --allow-outies -z -d /Users/arman/Desktop/crispresso_test/run/foo/CRISPResso_on_nhej -o out >>/Users/arman/Desktop/crispresso_test/run/foo/CRISPResso_on_nhej/CRISPResso_RUNNING_LOG.txt 2>&1

INFO  @ Tue, 25 Oct 2022 15:08:39:
	 Done!

INFO  @ Tue, 25 Oct 2022 15:08:39:
	 Aligning sequences...

INFO  @ Tue, 25 Oct 2022 15:08:39:
	 Processing reads; N_TOT_READS: 0 N_COMPUTED_ALN: 0 N_CACHED_ALN: 0 N_COMPUTED_NOTALN: 0 N_CACHED_NOTALN: 0

INFO  @ Tue, 25 Oct 2022 15:08:39:
	 Processing reads; N_TOT_READS: 10000 N_COMPUTED_ALN: 1804 N_CACHED_ALN: 8104 N_COMPUTED_NOTALN: 64 N_CACHED_NOTALN: 28

INFO  @ Tue, 25 Oct 2022 15:08:40:
	 Processing reads; N_TOT_READS: 20000 N_COMPUTED_ALN: 2959 N_CACHED_ALN: 16846 N_COMPUTED_NOTALN: 111 N_CACHED_NOTALN: 84

INFO  @ Tue, 25 Oct 2022 15:08:40:
	 Finished reads; N_TOT_READS: 24719 N_COMPUTED_ALN: 3393 N_CACHED_ALN: 21085 N_COMPUTED_NOTALN: 133 N_CACHED_NOTALN: 108

INFO  @ Tue, 25 Oct 2022 15:08:40:
	 Done!

INFO  @ Tue, 25 Oct 2022 15:08:40:
	 Quantifying indels/substitutions...

INFO  @ Tue, 25 Oct 2022 15:08:40:
	 Done!

INFO  @ Tue, 25 Oct 2022 15:08:40:
	 Calculating allele frequencies...

INFO  @ Tue, 25 Oct 2022 15:08:40:
	 Done!

INFO  @ Tue, 25 Oct 2022 15:08:40:
	 Saving processed data...

INFO  @ Tue, 25 Oct 2022 15:08:40:
	 Making Plots...

INFO  @ Tue, 25 Oct 2022 15:08:45:
	 Done!

INFO  @ Tue, 25 Oct 2022 15:08:45:
	 Removing Intermediate files...

INFO  @ Tue, 25 Oct 2022 15:08:45:
	 Analysis Complete!


                                        _
                                       '  )
                                       .-'
                                      (____
                                   C)|     \
                                     \     /
                                      \___/
```

This also fails since the parent directory name has a space in it although the `output_folder` doesn't:

```bash
$ pwd
/Users/arman/Desktop/crispresso_test/run foo bar

$ CRISPResso --fastq_r1 nhej.r1.fastq.gz --fastq_r2 nhej.r2.fastq.gz --amplicon_seq AATGTCCCCCAATGGGAAGTTCATCTGGCACTGCCCACAGGTGAGGAGGTCATGATCCCCTTCTGGAGCTCCCAACGGGCCGTGGTCTGGTTCATCATCTGTAAGAATGGCTTCAAGAGGCTCGGCTGTGGTT -n nhej --output_folder foo

                               ~~~CRISPResso 2~~~
        -Analysis of genome editing outcomes from deep sequencing data-

                                        _
                                       '  )
                                       .-'
                                      (____
                                   C)|     \
                                     \     /
                                      \___/

                          [CRISPResso version 2.2.11]
[Note that starting in version 2.1.0 insertion quantification has been changed
to only include insertions completely contained by the quantification window.
To use the legacy quantification method (i.e. include insertions directly adjacent
to the quantification window) please use the parameter --use_legacy_insertion_quantification]
                 [For support contact kclement@mgh.harvard.edu]

INFO  @ Tue, 25 Oct 2022 15:10:50:
	 Creating Folder /Users/arman/Desktop/crispresso_test/run foo bar/foo/CRISPResso_on_nhej

INFO  @ Tue, 25 Oct 2022 15:10:50:
	 Estimating average read length...

INFO  @ Tue, 25 Oct 2022 15:10:50:
	 Merging paired sequences with Flash...

INFO  @ Tue, 25 Oct 2022 15:10:50:
	 Running FLASH command: flash "nhej.r1.fastq.gz" "nhej.r2.fastq.gz" --min-overlap 10 --max-overlap 100 --allow-outies -z -d /Users/arman/Desktop/crispresso_test/run foo bar/foo/CRISPResso_on_nhej -o out >>/Users/arman/Desktop/crispresso_test/run foo bar/foo/CRISPResso_on_nhej/CRISPResso_RUNNING_LOG.txt 2>&1

/bin/sh: /Users/arman/Desktop/crispresso_test/run: Is a directory
CRITICAL @ Tue, 25 Oct 2022 15:10:50:
	 Merging error, please check your input.

ERROR: Flash failed to run, please check the log file.
```

Quoting the file/folder names in the flash command resolves this issue.
