### PR TITLE
Fix running plots in parallel

### DIFF
--- a/CRISPResso2/CRISPRessoMultiProcessing.py
+++ b/CRISPResso2/CRISPRessoMultiProcessing.py
@@ -272,6 +272,6 @@ def run_plot(plot_func, plot_args, num_processes, process_results, process_pool)
     None
     """
     if num_processes > 1:
-        process_results.append(process_pool.submit(plot_func(**plot_args)))
+        process_results.append(process_pool.submit(plot_func, **plot_args))
     else:
         plot_func(**plot_args)


### PR DESCRIPTION
The reason the plots were running slower before this change is because I was calling the plot function, not passing it to `submit`. So it was essentially running in serial, but worse because it was still spinning up/down the processes.