### PR TITLE
Fix samtools piping

### DIFF
--- a/CRISPResso2/CRISPRessoWGSCORE.py
+++ b/CRISPResso2/CRISPRessoWGSCORE.py
@@ -317,13 +317,13 @@ def main():
             ))
             sys.exit()
 
-        parser = CRISPRessoShared.getCRISPRessoArgParser(parser_title = 'CRISPRessoWGS Parameters', required_params=[], 
+        parser = CRISPRessoShared.getCRISPRessoArgParser(parser_title = 'CRISPRessoWGS Parameters', required_params=[],
                     suppress_params=['bam_input',
-                                   'bam_chr_loc'
-                                   'fastq_r1', 
-                                   'fastq_r2', 
-                                   'amplicon_seq', 
-                                   'amplicon_name', 
+                                   'bam_chr_loc',
+                                   'fastq_r1',
+                                   'fastq_r2',
+                                   'amplicon_seq',
+                                   'amplicon_name',
                                    ])
 
         #tool specific optional

--- a/CRISPResso2/CRISPRessoWGSCORE.py
+++ b/CRISPResso2/CRISPRessoWGSCORE.py
@@ -171,13 +171,18 @@ def write_trimmed_fastq(in_bam_filename, bpstart, bpend, out_fastq_filename):
         n_reasd (int): number of reads written to the output fastq file
     """
     p = sb.Popen(
-                'samtools view %s | cut -f1,4,6,10,11' % in_bam_filename,
-                stdout = sb.PIPE,
-                shell=True
-                )
+        f'samtools view {in_bam_filename} | cut -f1,4,6,10,11',
+        stdout=sb.PIPE,
+        stderr=sb.PIPE,
+        shell=True,
+        text=True,
+    )
 
-    output=p.communicate()[0].decode('utf-8')
-    n_reads=0
+    output, stderr = p.communicate()
+    n_reads = 0
+    if stderr:
+        logger.debug('Stderr from samtools view:')
+        logger.debug(stderr)
 
     with gzip.open(out_fastq_filename, 'wt') as outfile:
         for line in output.split('\n'):

--- a/CRISPResso2/CRISPRessoWGSCORE.py
+++ b/CRISPResso2/CRISPRessoWGSCORE.py
@@ -173,7 +173,6 @@ def write_trimmed_fastq(in_bam_filename, bpstart, bpend, out_fastq_filename):
     p = sb.Popen(
                 'samtools view %s | cut -f1,4,6,10,11' % in_bam_filename,
                 stdout = sb.PIPE,
-                stderr = sb.STDOUT,
                 shell=True
                 )
 


### PR DESCRIPTION
Sometimes some of the libraries that samtools depends on don't have the correct
version information (happens in Docker), and as such samtools will report this to stderr when run.
Because we pipe the output of samtools, we expect it to be valid SAM format, but
when these library version messages are reported, it breaks CRISPRessoWGS.

This also fixes a bug where a comma was missing in suppressing the parameters on CRISPRessoWGS. Before this fix, `['bam_input', 'bam_chr_locfastq_r1', 'fastq_r2', 'amplicon_seq', 'amplicon_name']` was being passed as `suppress_params` to `CRISPRessoShared.getCRISPRessoArgParser()`. After the fix, `['bam_input', 'bam_chr_loc', 'fastq_r1', 'fastq_r2', 'amplicon_seq', 'amplicon_name']` is being passed as `suppress_params`. This change allows `bam_chr_loc` and `fastq_r1` to both be suppressed in WGS mode, the only change in behavior is that `bam_chr_loc` will no longer show up in the WGS help menu or be allowed to be passed in. `bam_chr_loc` is not used in WGS anyways, so there should be no functional change.

CC @Snicker7 