### PR TITLE
Prime editing alignment params

### DIFF
--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -23,7 +23,7 @@ import logging
 from CRISPResso2 import CRISPResso2Align
 from CRISPResso2 import CRISPRessoCOREResources
 
-__version__ = "2.2.14"
+__version__ = "2.2.15"
 
 
 ###EXCEPTIONS############################

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -336,7 +336,7 @@ def getCRISPRessoArgParser(parser_title="CRISPResso Parameters", required_params
                         help="If set, checks to assert that the prime editing guides and extension sequence are in the proper orientation are not performed. This may be useful if the checks are failing inappropriately, but the user is confident that the sequences are correct.",
                         action='store_true')
     parser.add_argument('--prime_editing_gap_open_penalty',
-                        help=argparse.SUPPRESS, type=int, default=-20)
+                        help=argparse.SUPPRESS, type=int, default=-50)
                         # help="If set, adjusts the alignment gap open penalty for calculating alignment between pegRNA components (e.g. spacer and extension)."
     parser.add_argument('--prime_editing_gap_extend_penalty',
                         help=argparse.SUPPRESS, type=int, default=0)

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -335,6 +335,12 @@ def getCRISPRessoArgParser(parser_title="CRISPResso Parameters", required_params
     parser.add_argument('--prime_editing_override_sequence_checks',
                         help="If set, checks to assert that the prime editing guides and extension sequence are in the proper orientation are not performed. This may be useful if the checks are failing inappropriately, but the user is confident that the sequences are correct.",
                         action='store_true')
+    parser.add_argument('--prime_editing_gap_open_penalty',
+                        help=argparse.SUPPRESS, type=int, default=-20)
+                        # help="If set, adjusts the alignment gap open penalty for calculating alignment between pegRNA components (e.g. spacer and extension)."
+    parser.add_argument('--prime_editing_gap_extend_penalty',
+                        help=argparse.SUPPRESS, type=int, default=0)
+                        # help="If set, adjusts the alignment gap extension penalty for calculating alignment between pegRNA components (e.g. spacer and extension). Because prime editing may introduce large insertions/deletions, this is set to 0 to preference these large insertions."
 
     # special running modes
     parser.add_argument('--crispresso1_mode', help='Parameter usage as in CRISPResso 1', action='store_true')


### PR DESCRIPTION
Adds two parameters to control alignment of pegRNA components: `--prime_editing_gap_open_penalty` and `--prime_editing_gap_extend_penalty`.

CRISPResso checks to see whether the pegRNA spacer and extension sequence are in the correct orientation, but sometimes they could align in the incorrect orientation with a higher score (e.g. via insertion of multiple gaps, whereas a single long gap would be preferred). Introducing these two parameters allows users to adjust the alignment parameters specifically for these prime-editing checks without adjusting the global alignment parameters which will be applied to reads that are aligned to the WT reference/prime-editing reference sequences. 

The new prime_editing_gap_open_penalty is set to -50, a higher gap open penalty than the default needleman_wunsch_gap_open penalty (-20). This commit breaks backward-reproducibility, but mostly in the checking of pegRNA component orientation - so previously some CRISPResso runs would have failed and produced an error, but now they will (hopefully) succeed. To achieve complete backward reproducibility, add the flag `--prime_editing_gap_open_penalty -20` to runs.