### PR TITLE
Fix for recent Matplotlib v3.8

### DIFF
--- a/CRISPResso2/CRISPRessoPlot.py
+++ b/CRISPResso2/CRISPRessoPlot.py
@@ -1831,7 +1831,7 @@ def plot_scaffold_indel_lengths(
     plot_root,
     save_also_png=False,
 ):
-    colors = 'b', 'g'
+    colors = ['b', 'g']
     fig, ax = plt.subplots(figsize=(12, 6))
     ax.hist(
         [


### PR DESCRIPTION
The new version of Matplotlib (3.8) has a new way to [input colors using tuples](https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.8.0.html#id14) which breaks this function unless the colors are a list.

This PR fixes it.