### PR TITLE
Fix Matplotlib breaking change issue

### DIFF
--- a/CRISPResso2/CRISPRessoPlot.py
+++ b/CRISPResso2/CRISPRessoPlot.py
@@ -1831,7 +1831,7 @@ def plot_scaffold_indel_lengths(
     plot_root,
     save_also_png=False,
 ):
-    colors = 'b', 'g'
+    colors = ['b', 'g']
     fig, ax = plt.subplots(figsize=(12, 6))
     ax.hist(
         [


### PR DESCRIPTION
In a new version of Matplotlib, colors are represented differently. When the color is represented as a tuple it expects to have an alpha value, but when it is represented as a list it produces the expected behavior.