### PR TITLE
Move read filtering to after merging in CRISPResso

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,7 +2,9 @@ name: Run Integration Tests
 
 on:
   push:
+  
   pull_request:
+    types: [opened, reopened]
 
 jobs:
   build:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,6 +2,7 @@ name: Run Integration Tests
 
 on:
   push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         mkdir ../CRISPResso2_copy
         cp -r * ../CRISPResso2_copy
-        
+
     - name: Copy C2_tests repo
       uses: actions/checkout@master
       with:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,7 +2,9 @@ name: Pylint
 
 on:
   push:
+  
   pull_request:
+    types: [opened, reopened]
 
 jobs:
   build:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,7 @@ name: Pylint
 
 on:
   push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,7 @@ name: Run Pytest
 
 on:
   push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,7 +2,9 @@ name: Run Pytest
 
 on:
   push:
+  
   pull_request:
+    types: [opened, reopened]
 
 jobs:
   build:

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -2117,44 +2117,6 @@ def main():
 
                 info('Done!', {'percent_complete': 4})
 
-        if args.min_average_read_quality>0 or args.min_single_bp_quality>0 or args.min_bp_quality_or_N>0:
-            if args.bam_input != '':
-                raise CRISPRessoShared.BadParameterException('The read filtering options are not available with bam input')
-            info('Filtering reads with average bp quality < %d and single bp quality < %d and replacing bases with quality < %d with N ...' % (args.min_average_read_quality, args.min_single_bp_quality, args.min_bp_quality_or_N))
-            min_av_quality = None
-            if args.min_average_read_quality > 0:
-                min_av_quality = args.min_average_read_quality
-
-            min_single_bp_quality = None
-            if args.min_single_bp_quality > 0:
-                min_single_bp_quality = args.min_single_bp_quality
-
-            min_bp_quality_or_N = None
-            if args.min_bp_quality_or_N > 0:
-                min_bp_quality_or_N = args.min_bp_quality_or_N
-
-            if args.fastq_r2!='':
-                output_filename_r1=_jp(os.path.basename(args.fastq_r1.replace('.fastq', '')).replace('.gz', '')+'_filtered.fastq.gz')
-                output_filename_r2=_jp(os.path.basename(args.fastq_r2.replace('.fastq', '')).replace('.gz', '')+'_filtered.fastq.gz')
-
-                from CRISPResso2 import filterFastqs
-                filterFastqs.filterFastqs(fastq_r1=args.fastq_r1, fastq_r2=args.fastq_r2, fastq_r1_out=output_filename_r1, fastq_r2_out=output_filename_r2, min_bp_qual_in_read=min_single_bp_quality, min_av_read_qual=min_av_quality, min_bp_qual_or_N=min_bp_quality_or_N)
-
-                args.fastq_r1 = output_filename_r1
-                args.fastq_r2 = output_filename_r2
-                files_to_remove += [output_filename_r1]
-                files_to_remove += [output_filename_r2]
-
-            else:
-                output_filename_r1=_jp(os.path.basename(args.fastq_r1.replace('.fastq', '')).replace('.gz', '')+'_filtered.fastq.gz')
-
-                from CRISPResso2 import filterFastqs
-                filterFastqs.filterFastqs(fastq_r1=args.fastq_r1, fastq_r1_out=output_filename_r1, min_bp_qual_in_read=min_single_bp_quality, min_av_read_qual=min_av_quality, min_bp_qual_or_N=min_bp_quality_or_N)
-
-                args.fastq_r1 = output_filename_r1
-                files_to_remove += [output_filename_r1]
-
-
         #Trim and merge reads
         if args.bam_input != '' and args.trim_sequences:
             raise CRISPRessoShared.BadParameterException('Read trimming options are not available with bam input')
@@ -2292,7 +2254,33 @@ def main():
                      info('Wrote force-merged reads to ' + new_merged_filename)
 
             info('Done!', {'percent_complete': 7})
+        else: # single end reads with no trimming
+            processed_output_filename = args.fastq_r1
 
+        if args.min_average_read_quality > 0 or args.min_single_bp_quality > 0 or args.min_bp_quality_or_N > 0:
+            if args.bam_input != '':
+                raise CRISPRessoShared.BadParameterException('The read filtering options are not available with bam input')
+            info('Filtering reads with average bp quality < %d and single bp quality < %d and replacing bases with quality < %d with N ...' % (args.min_average_read_quality, args.min_single_bp_quality, args.min_bp_quality_or_N))
+            min_av_quality = None
+            if args.min_average_read_quality > 0:
+                min_av_quality = args.min_average_read_quality
+
+            min_single_bp_quality = None
+            if args.min_single_bp_quality > 0:
+                min_single_bp_quality = args.min_single_bp_quality
+
+            min_bp_quality_or_N = None
+            if args.min_bp_quality_or_N > 0:
+                min_bp_quality_or_N = args.min_bp_quality_or_N
+
+            output_filename_r1 = _jp(os.path.basename(
+                processed_output_filename.replace('.fastq', '')).replace('.gz', '') + '_filtered.fastq.gz',
+            )
+
+            from CRISPResso2 import filterFastqs
+            filterFastqs.filterFastqs(fastq_r1=processed_output_filename, fastq_r1_out=output_filename_r1, min_bp_qual_in_read=min_single_bp_quality, min_av_read_qual=min_av_quality, min_bp_qual_or_N=min_bp_quality_or_N)
+
+            processed_output_filename = output_filename_r1
 
         #count reads
         N_READS_AFTER_PREPROCESSING = 0

--- a/CRISPResso2/CRISPRessoReports/README.md
+++ b/CRISPResso2/CRISPRessoReports/README.md
@@ -86,10 +86,16 @@ Also, note that the default commit message may have a summary of all commits, pl
 
 1. In the parent repo, switch to (or create) the branch on `CRISPRessoReports` that will have the changes you push.
 
-If you are creating a new branch based off of `CRISPRessoReports` master, run this:
+If you are creating a new branch based off of `CRISPRessoReports` master, run this to switch to the reports master branch:
 
 ``` shell
-git checkout -b <feature-branch>-reports reports/master
+git checkout reports/master
+```
+
+Then, run to actually create (and switch to) the branch that you will be working with:
+
+``` shell
+git checkout -b <feature-branch>-reports
 ```
 
 Or if you would like to push to an existing branch on `CRISPRessoReports`, run this:
@@ -106,6 +112,18 @@ git merge --squash -Xsubtree="CRISPResso2/CRISPRessoReports" --no-commit --allow
 
 *Note:* `<feature-branch>` is the branch of the parent repo that contains the changes inside the `CRISPRessoReports` sub-directory.
 
+3. Push to `CRISPRessoReports`.
+
+``` shell
+git push
+```
+
+4. Switch back to your branch on `CRISPResso` or `C2Web`.
+
+``` shell
+git checkout <feature-branch>
+```
+
 ### I am working on a feature that requires changing `CRISPRessoReports`, what do I do?
 
 If a feature that you are working on requires changes to CRISPRessoReports, you will need to perform a few steps to get setup.
@@ -113,7 +131,7 @@ If a feature that you are working on requires changes to CRISPRessoReports, you 
 1. Create a feature branch in the parent repo, based on the parent repo master.
 
 ``` shell
-git checkout -b <feature-branch> origin/master
+git checkout -b <feature-branch>
 ```
 
 2. Create a feature branch on `CRISPRessoReports`.

--- a/CRISPResso2/CRISPRessoReports/templates/batchReport.html
+++ b/CRISPResso2/CRISPRessoReports/templates/batchReport.html
@@ -45,7 +45,6 @@
 {% endblock %}
 
 {% block content %}
-
 <div class="row">
 <div class="col-sm-1"></div>
 <div class="col-sm-10">

--- a/CRISPResso2/CRISPRessoReports/templates/multiReport.html
+++ b/CRISPResso2/CRISPRessoReports/templates/multiReport.html
@@ -46,7 +46,7 @@
 {% endblock %}
 
 {% block content %}
-
+<div class="row">
 <div class="col-sm-1"></div>
 <div class="col-sm-10">
 
@@ -61,7 +61,7 @@
               <div class='card-body p-0'>
                 <div class="list-group list-group-flush" style='max-height:80vh;overflow-y:auto'>
               {% for run_name in run_names %}
-	              <a href="{{report_data['crispresso_data_path']}}{{sub_html_files[run_name]}}" class="list-group-item list-group-item-action">{{run_name}}</a>
+	              <a href="{{sub_html_files[run_name]}}" class="list-group-item list-group-item-action">{{run_name}}</a>
                   {% endfor %}
                 </div>
               </div>
@@ -162,6 +162,7 @@
 </div> {# column #} <!-- end column -->
 
 <div class="col-sm-1"></div>
+</div>
 {% endblock %}
 
 {% block foot %}

--- a/CRISPResso2/CRISPRessoReports/templates/pooledReport.html
+++ b/CRISPResso2/CRISPRessoReports/templates/pooledReport.html
@@ -44,7 +44,6 @@
 {% endblock %}
 
 {% block content %}
-
 <div class="row">
 <div class="col-sm-1"></div>
 <div class="col-sm-10">
@@ -60,8 +59,8 @@
                 <div class='card-body p-0'>
                     <div class="list-group list-group-flush">
                         {% for region_name in run_names %}
-	                  <a href="{{sub_html_files[region_name]}}" class="list-group-item list-group-item-action">{{region_name}}</a>
-                      {% endfor %}
+	                    <a href="{{sub_html_files[region_name]}}" class="list-group-item list-group-item-action">{{region_name}}</a>
+                        {% endfor %}
                     </div>
                 </div>
             </div>

--- a/CRISPResso2/CRISPRessoReports/templates/wgsReport.html
+++ b/CRISPResso2/CRISPRessoReports/templates/wgsReport.html
@@ -45,7 +45,6 @@
 {% endblock %}
 
 {% block content %}
-
 <div class="row">
 <div class="col-sm-1"></div>
 <div class="col-sm-10">
@@ -60,8 +59,8 @@
                 <div class="card-body p-0">
                     <div class="list-group list-group-flush">
                         {% for region_name in run_names %}
-                      <a href="{{sub_html_files[region_name]}}" class="list-group-item list-group-item-action" id="{{region_name}}">{{region_name}}</a>
-                      {% endfor %}
+                        <a href="{{sub_html_files[region_name]}}" class="list-group-item list-group-item-action" id="{{region_name}}">{{region_name}}</a>
+                        {% endfor %}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
* Move read filtering to after merging

This is in an effort to be consistent with the behavior and results of CRISPRessoPooled.

* Properly assign the correct file names for read filtering

* Add space around operators