### PR TITLE
Fix Jinja2 undefined variables

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,7 +2,7 @@ name: Run Integration Tests
 
 on:
   push:
-  
+
   pull_request:
     types: [opened, reopened]
 

--- a/CRISPResso2/CRISPRessoReports/CRISPRessoReport.py
+++ b/CRISPResso2/CRISPRessoReports/CRISPRessoReport.py
@@ -5,22 +5,27 @@ Software pipeline for the analysis of genome editing outcomes from deep sequenci
 '''
 
 import os
-from jinja2 import Environment, FileSystemLoader, PackageLoader, ChoiceLoader
+from jinja2 import Environment, FileSystemLoader, ChoiceLoader
 from jinja_partials import generate_render_partial, render_partial
 from CRISPResso2 import CRISPRessoShared
 
 if CRISPRessoShared.is_C2Pro_installed():
-    from CRISPRessoPro import __version__ as CRISPRessoProVersion
+    import CRISPRessoPro
     C2PRO_INSTALLED = True
 else:
     C2PRO_INSTALLED = False
 
 
-def get_jinja_loader(_ROOT):
-    if CRISPRessoShared.is_C2Pro_installed():
-        return Environment(loader=ChoiceLoader([FileSystemLoader(os.path.join(_ROOT, 'CRISPRessoReports', 'templates')), PackageLoader('CRISPRessoPro', 'templates')]))    
+def get_jinja_loader(root):
+    if C2PRO_INSTALLED:
+        return Environment(
+            loader=ChoiceLoader([
+                FileSystemLoader(os.path.join(root, 'CRISPRessoReports', 'templates')),
+                FileSystemLoader(os.path.join(os.path.dirname(CRISPRessoPro.__file__), 'templates')),
+            ]),
+        )
     else:
-        return Environment(loader=FileSystemLoader(os.path.join(_ROOT, 'CRISPRessoReports', 'templates')))
+        return Environment(loader=FileSystemLoader(os.path.join(root, 'CRISPRessoReports', 'templates')))
 
 
 def render_template(template_name, jinja2_env, **data):

--- a/CRISPResso2/CRISPRessoReports/templates/report.html
+++ b/CRISPResso2/CRISPRessoReports/templates/report.html
@@ -179,7 +179,7 @@
 			{# end of global coding sequence analysis #}
 
 			{# start hdr summary #}
-			{% if report_data['figures']['locs'][report_data.amplicons[0]]['plot_4g'] or 'plot_4g' in report_data['figures']['htmls'][amplicon_name] %}
+			{% if report_data['figures']['locs'][report_data.amplicons[0]]['plot_4g'] or 'plot_4g' in report_data['figures']['htmls'][report_data.amplicons[0]] %}
 			<div class='card text-center mb-2 breakinpage'>
 				<div class='card-header'>
 					{% if report_data.amplicons|length == 1 %} {# if only one amplicon #}
@@ -189,11 +189,7 @@
 					{% endif %}
 				</div>
 				<div class='card-body'>
-					{% if 'plot_4g' in report_data['figures']['htmls'][amplicon_name] %}
-						{{ report_data['figures']['htmls'][amplicon_name]['plot_4g']|safe }}
-					{% else %}
-						{{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_4g', amplicon_name=report_data.amplicons[0])}}
-					{% endif %}
+                  {{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_4g', amplicon_name=report_data.amplicons[0])}}
 				</div>
 			</div>
 			{% endif %}


### PR DESCRIPTION
* Replace Jinja2 PackageLoader with FileSystemLoader

The PackageLoader doesn't work with a fairly recent version of Jinja2 (3.0.1) and Python 3.9. Replacing with FileSystemLoader work with the older version and the latest version.

* Fix undefined variable `amplicon_name` in report template

* Revert plot_11a update

* Update intedration test branch

* Update branch for integration tests