### PR TITLE
Cole/refactor jinja undefined (#66)

### DIFF
--- a/CRISPResso2/CRISPRessoBatchCORE.py
+++ b/CRISPResso2/CRISPRessoBatchCORE.py
@@ -170,7 +170,7 @@ def main():
         num_batches = batch_params.shape[0]
         if int(n_processes_for_batch/num_batches) > 1:
             args.n_processes = int(n_processes_for_batch/num_batches)
-        
+
         int_columns = ['default_min_aln_score', 'min_average_read_quality', 'min_single_bp_quality',
                        'min_bp_quality_or_N',
                        'quantification_window_size', 'quantification_window_center', 'exclude_bp_from_left',
@@ -909,7 +909,7 @@ def main():
                 report_name = _jp("CRISPResso2Batch_report.html")
             else:
                 report_name = OUTPUT_DIRECTORY+'.html'
-            CRISPRessoReport.make_batch_report_from_folder(report_name, crispresso2_info, OUTPUT_DIRECTORY, _ROOT)
+            CRISPRessoReport.make_batch_report_from_folder(report_name, crispresso2_info, OUTPUT_DIRECTORY, _ROOT, logger)
             crispresso2_info['running_info']['report_location'] = report_name
             crispresso2_info['running_info']['report_filename'] = os.path.basename(report_name)
 

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -600,7 +600,7 @@ def process_fastq(fastq_filename, variantCache, ref_names, refs, args):
                 N_MODS_OUTSIDE_WINDOW += new_variant[match_name]['mods_outside_window']
                 if new_variant[match_name]['irregular_ends']:
                     N_READS_IRREGULAR_ENDS += 1
-                
+
 
     fastq_handle.close()
 
@@ -4967,7 +4967,7 @@ def main():
                 report_name = _jp("CRISPResso2_report.html")
             else:
                 report_name = OUTPUT_DIRECTORY+'.html'
-            CRISPRessoReport.make_report(crispresso2_info, report_name, OUTPUT_DIRECTORY, _ROOT)
+            CRISPRessoReport.make_report(crispresso2_info, report_name, OUTPUT_DIRECTORY, _ROOT, logger)
             crispresso2_info['running_info']['report_location'] = report_name
             crispresso2_info['running_info']['report_filename'] = os.path.basename(report_name)
 

--- a/CRISPResso2/CRISPRessoCompareCORE.py
+++ b/CRISPResso2/CRISPRessoCompareCORE.py
@@ -83,7 +83,7 @@ def main():
         '''
         compare_header = CRISPRessoShared.get_crispresso_header(description, compare_header)
         print(compare_header)
-        
+
         parser = CRISPRessoShared.getCRISPRessoArgParser("Compare", parser_title = 'CRISPRessoCompare Parameters')
 
         args = parser.parse_args()
@@ -429,7 +429,7 @@ def main():
                 report_name = _jp("CRISPResso2Compare_report.html")
             else:
                 report_name = OUTPUT_DIRECTORY+'.html'
-            CRISPRessoReport.make_compare_report_from_folder(report_name, crispresso2_info, OUTPUT_DIRECTORY, _ROOT)
+            CRISPRessoReport.make_compare_report_from_folder(report_name, crispresso2_info, OUTPUT_DIRECTORY, _ROOT, logger)
             crispresso2_info['running_info']['report_location'] = report_name
             crispresso2_info['running_info']['report_filename'] = os.path.basename(report_name)
 

--- a/CRISPResso2/CRISPRessoMetaCORE.py
+++ b/CRISPResso2/CRISPRessoMetaCORE.py
@@ -358,7 +358,7 @@ def main():
                 report_name = _jp("CRISPResso2Meta_report.html")
             else:
                 report_name = OUTPUT_DIRECTORY+'.html'
-            CRISPRessoReport.make_meta_report_from_folder(report_name, crispresso2_info, OUTPUT_DIRECTORY, _ROOT)
+            CRISPRessoReport.make_meta_report_from_folder(report_name, crispresso2_info, OUTPUT_DIRECTORY, _ROOT, logger)
             crispresso2_info['running_info']['report_location'] = report_name
             crispresso2_info['running_info']['report_filename'] = os.path.basename(report_name)
 

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -1593,7 +1593,7 @@ def main():
                 report_name = _jp("CRISPResso2Pooled_report.html")
             else:
                 report_name = OUTPUT_DIRECTORY+'.html'
-            CRISPRessoReport.make_pooled_report_from_folder(report_name, crispresso2_info, OUTPUT_DIRECTORY, _ROOT)
+            CRISPRessoReport.make_pooled_report_from_folder(report_name, crispresso2_info, OUTPUT_DIRECTORY, _ROOT, logger)
             crispresso2_info['running_info']['report_location'] = report_name
             crispresso2_info['running_info']['report_filename'] = os.path.basename(report_name)
 

--- a/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
+++ b/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
@@ -367,6 +367,7 @@ increase the memory required to run CRISPResso. Can be set to 'max'.
                 'CRISPREssoPooledWGSCompare Report<br>{0} vs {1}'.format(
                     sample_1_name, sample_2_name,
                 ),
+                logger,
             )
             crispresso2_info['running_info']['report_location'] = report_name
             crispresso2_info['running_info']['report_filename'] = os.path.basename(report_name)

--- a/CRISPResso2/CRISPRessoReports/CRISPRessoReport.py
+++ b/CRISPResso2/CRISPRessoReports/CRISPRessoReport.py
@@ -5,7 +5,7 @@ Software pipeline for the analysis of genome editing outcomes from deep sequenci
 '''
 
 import os
-from jinja2 import Environment, FileSystemLoader, ChoiceLoader
+from jinja2 import Environment, FileSystemLoader, ChoiceLoader, make_logging_undefined
 from jinja_partials import generate_render_partial, render_partial
 from CRISPResso2 import CRISPRessoShared
 
@@ -16,16 +16,21 @@ else:
     C2PRO_INSTALLED = False
 
 
-def get_jinja_loader(root):
+def get_jinja_loader(root, logger):
+    UndefinedLogger = make_logging_undefined(logger=logger)
     if C2PRO_INSTALLED:
         return Environment(
             loader=ChoiceLoader([
                 FileSystemLoader(os.path.join(root, 'CRISPRessoReports', 'templates')),
                 FileSystemLoader(os.path.join(os.path.dirname(CRISPRessoPro.__file__), 'templates')),
             ]),
+            undefined=UndefinedLogger,
         )
     else:
-        return Environment(loader=FileSystemLoader(os.path.join(root, 'CRISPRessoReports', 'templates')))
+        return Environment(
+            loader=FileSystemLoader(os.path.join(root, 'CRISPRessoReports', 'templates')),
+            undefined=UndefinedLogger,
+        )
 
 
 def render_template(template_name, jinja2_env, **data):
@@ -172,7 +177,7 @@ def assemble_figs(run_data, crispresso_folder):
     return data
 
 
-def make_report(run_data, crispresso_report_file, crispresso_folder, _ROOT):
+def make_report(run_data, crispresso_report_file, crispresso_folder, _ROOT, logger):
     # dicts for each amplicon fig_names[amp_name] = [list of fig names]
     #                        fig_locs[amp_name][fig_name] = figure location
     #    print('crispresso_report file: ' + crispresso_report_file + ' crispresso_folder : ' + crispresso_folder + ' root: ' + _ROOT)
@@ -198,7 +203,7 @@ def make_report(run_data, crispresso_report_file, crispresso_folder, _ROOT):
         'nuc_quilt_names': data['nuc_quilt_names'],
     }
 
-    j2_env = get_jinja_loader(_ROOT)
+    j2_env = get_jinja_loader(_ROOT, logger)
 
     #    dest_dir = os.path.dirname(crispresso_report_file)
     #    shutil.copy2(os.path.join(_ROOT,'templates','CRISPResso_justcup.png'),dest_dir)
@@ -210,7 +215,7 @@ def make_report(run_data, crispresso_report_file, crispresso_folder, _ROOT):
         ))
 
 
-def make_batch_report_from_folder(crispressoBatch_report_file, crispresso2_info, batch_folder, _ROOT):
+def make_batch_report_from_folder(crispressoBatch_report_file, crispresso2_info, batch_folder, _ROOT, logger):
     batch_names = crispresso2_info['results']['completed_batch_arr']
     failed_runs = crispresso2_info['results']['failed_batch_arr']
     failed_runs_desc = crispresso2_info['results']['failed_batch_arr_desc']
@@ -336,6 +341,7 @@ def make_batch_report_from_folder(crispressoBatch_report_file, crispresso2_info,
         _ROOT,
         output_title,
         'batch',
+        logger,
         summary_plots={
             'names': summary_plot_names,
             'titles': summary_plot_titles,
@@ -352,41 +358,41 @@ def make_batch_report_from_folder(crispressoBatch_report_file, crispresso2_info,
     )
 
 
-def make_pooled_report_from_folder(crispresso_report_file, crispresso2_info, folder, _ROOT):
+def make_pooled_report_from_folder(crispresso_report_file, crispresso2_info, folder, _ROOT, logger):
     names_arr = crispresso2_info['results']['good_region_names']
     output_title = 'CRISPResso Pooled Output'
     if crispresso2_info['running_info']['args'].name != '':
         output_title += f"<br/>{crispresso2_info['running_info']['args'].name}"
-    make_multi_report_from_folder(crispresso2_info, names_arr, output_title, crispresso_report_file, folder, _ROOT, 'pooled')
+    make_multi_report_from_folder(crispresso2_info, names_arr, output_title, crispresso_report_file, folder, _ROOT, 'pooled', logger)
 
 
-def make_compare_report_from_folder(crispresso_report_file, crispresso2_info, folder, _ROOT):
+def make_compare_report_from_folder(crispresso_report_file, crispresso2_info, folder, _ROOT, logger):
     names_arr = []
     output_title = 'CRISPResso Compare Output'
     if crispresso2_info['running_info']['args'].name != '':
         output_title += "<br/>{crispresso2_info['running_info']['args'].name}"
-    make_multi_report_from_folder(crispresso2_info, names_arr, output_title, crispresso_report_file, folder, _ROOT, 'compare')
+    make_multi_report_from_folder(crispresso2_info, names_arr, output_title, crispresso_report_file, folder, _ROOT, 'compare', logger)
 
 
-def make_meta_report_from_folder(crispresso_report_file, crispresso2_info, folder, _ROOT):
+def make_meta_report_from_folder(crispresso_report_file, crispresso2_info, folder, _ROOT, logger):
     names_arr = crispresso2_info['meta_names_arr']
     input_names = crispresso2_info['meta_input_names']
     output_title = 'CRISPresso Meta Output'
     if crispresso2_info['running_info']['args'].name != '':
         output_title += "<br/>{crispresso2_info['running_info']['args'].name}"
-    make_multi_report_from_folder(crispresso2_info, names_arr, output_title, crispresso_report_file, folder, _ROOT, 'meta',
+    make_multi_report_from_folder(crispresso2_info, names_arr, output_title, crispresso_report_file, folder, _ROOT, 'meta', logger,
                                   display_names=input_names)
 
 
-def make_wgs_report_from_folder(crispresso_report_file, crispresso2_info, folder, _ROOT):
+def make_wgs_report_from_folder(crispresso_report_file, crispresso2_info, folder, _ROOT, logger):
     names_arr = crispresso2_info['results']['good_region_names']
     output_title = 'CRISPResso WGS Output'
     if crispresso2_info['running_info']['args'].name != '':
         output_title += "<br/>{crispresso2_info['running_info']['args'].name}"
-    make_multi_report_from_folder(crispresso2_info, names_arr, output_title, crispresso_report_file, folder, _ROOT, 'wgs')
+    make_multi_report_from_folder(crispresso2_info, names_arr, output_title, crispresso_report_file, folder, _ROOT, 'wgs', logger)
 
 
-def make_multi_report_from_folder(crispresso2_info, names_arr, report_name, crispresso_report_file, folder, _ROOT, crispresso_tool,
+def make_multi_report_from_folder(crispresso2_info, names_arr, report_name, crispresso_report_file, folder, _ROOT, crispresso_tool, logger,
                                   display_names=None):
     """
     Prepares information to make a report of multiple CRISPResso runs - like CRISPRessoWGS or CRISPRessoPooled
@@ -398,6 +404,7 @@ def make_multi_report_from_folder(crispresso2_info, names_arr, report_name, cris
     crispresso_report_file (string): path to write report to
     folder (string): folder containing crispresso runs
     _ROOT (string): location of crispresso assets (images, templates, etc)
+    logger (logging.Logger): logger to log messages to, mainly for undefined variables in Jinja2 templates
     display_names (dict): report_name->display_name; Titles to be shown for crispresso runs
         (if different from names_arr, e.g. if display_names have spaces or bad chars, they won't be the same as names_arr)
 
@@ -471,6 +478,7 @@ def make_multi_report_from_folder(crispresso2_info, names_arr, report_name, cris
         _ROOT,
         report_name,
         crispresso_tool,
+        logger,
         summary_plots={
             'names': summary_plot_names,
             'titles': summary_plot_titles,
@@ -490,6 +498,7 @@ def make_multi_report(
     _ROOT,
     report_name,
     crispresso_tool,
+    logger,
     window_nuc_pct_quilts=None,
     nuc_pct_quilts=None,
     window_nuc_conv_plots=None,
@@ -530,7 +539,7 @@ def make_multi_report(
         if key not in dictionary:
             dictionary[key] = default_type()
 
-    j2_env = get_jinja_loader(_ROOT)
+    j2_env = get_jinja_loader(_ROOT, logger)
 
     j2_env.filters['dirname'] = dirname
     if crispresso_tool == 'batch':

--- a/CRISPResso2/CRISPRessoReports/templates/report.html
+++ b/CRISPResso2/CRISPRessoReports/templates/report.html
@@ -119,7 +119,7 @@
 						<li class="nav-item">
 							<button class="nav-link" id="aln_bar-tab" data-bs-toggle="tab" data-bs-target="#aln_bar" role="tab" aria-controls="aln_bar" aria-selected="false">Barplot</button>
 						</li>
-    						{% if report_data['figures']['locs']['plot_1d'] %}
+    						{% if 'plot_1d' in report_data['figures']['locs'] %}
 						<li class="nav-item">
 							<button class="nav-link" id="aln_dsODN-tab" data-bs-toggle="tab" data-bs-target="#aln_dsODN" role="tab" aria-controls="aln_dsODN" aria-selected="false">dsODN</button>
 						</li>
@@ -134,7 +134,7 @@
 						<div class="tab-pane fade" id="aln_bar" role="tabpanel" aria-labelledby="aln_bar-tab">
 							{{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_1c')}}
 						</div>
-    						{% if report_data['figures']['locs']['plot_1d'] %}
+    						{% if 'plot_1d' in report_data['figures']['locs'] %}
 						<div class="tab-pane fade" id="aln_dsODN" role="tabpanel" aria-labelledby="aln_dsODN-tab">
 							{{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_1d')}}
 						</div>
@@ -144,7 +144,7 @@
 			</div> {# end card #}
 
         		{# start global coding sequence report #}
-			{% if report_data['figures']['locs']['plot_5a'] %}
+			{% if 'plot_5a' in report_data['figures']['locs'] %}
 			<div class='card text-center mb-2 breakinpage'>
 				<div class='card-header'>
 					<h5>Global frameshift analysis</h5>
@@ -155,7 +155,7 @@
 			</div>
 			{% endif %}
 
-			{% if report_data['figures']['locs']['plot_6a'] %}
+			{% if 'plot_6a' in report_data['figures']['locs'] %}
 			<div class='card text-center mb-2 breakinpage'>
 				<div class='card-header'>
 					<h5>Global frameshift mutagenesis profiles</h5>
@@ -166,7 +166,7 @@
 			</div>
 			{% endif %}
 
-			{% if report_data['figures']['locs']['plot_8a'] %}
+			{% if 'plot_8a' in report_data['figures']['locs'] %}
 			<div class='card text-center mb-2 breakinpage'>
 				<div class='card-header'>
 					<h5>Global splicing analysis</h5>
@@ -179,7 +179,7 @@
 			{# end of global coding sequence analysis #}
 
 			{# start hdr summary #}
-			{% if report_data['figures']['locs'][report_data.amplicons[0]]['plot_4g'] or 'plot_4g' in report_data['figures']['htmls'][report_data.amplicons[0]] %}
+			{% if 'plot_4g' in report_data['figures']['locs'][report_data.amplicons[0]] or 'plot_4g' in report_data['figures']['htmls'][report_data.amplicons[0]] %}
 			<div class='card text-center mb-2 breakinpage'>
 				<div class='card-header'>
 					{% if report_data.amplicons|length == 1 %} {# if only one amplicon #}
@@ -196,7 +196,7 @@
             		{# end HDR summary #}
 
 			{# start prime editing report #}
-			{% if report_data['figures']['locs'][report_data.amplicons[0]]['plot_11a'] %}
+			{% if 'plot_11a' in report_data['figures']['locs'][report_data.amplicons[0]] %}
 			<div class='card text-center mb-2 breakinpage'>
 				<div class='card-header'>
 					{% if report_data.amplicons|length == 1 %} {# if only one amplicon #}
@@ -211,7 +211,7 @@
 			</div>
 			{% endif %}
 
-			{% if report_data['figures']['sgRNA_based_names'][report_data.amplicons[0]] and  report_data['figures']['sgRNA_based_names'][report_data.amplicons[0]]['11b']%}
+			{% if report_data.amplicons[0] in report_data['figures']['sgRNA_based_names'] and '11b' in report_data['figures']['sgRNA_based_names'][report_data.amplicons[0]] and report_data['figures']['sgRNA_based_names'][report_data.amplicons[0]]['11b']|length > 0 %}
 			<div class='card text-center mb-2 breakinpage'>
 				<div class='card-header'>
 					{% if report_data.amplicons|length == 1 %} {# if only one amplicon #}
@@ -231,7 +231,7 @@
 			{% endif %}
 			{# end plot 11b for prime editing #}
 
-			{% if report_data['figures']['locs']['plot_11c'] %}
+			{% if 'plot_11c' in report_data['figures']['locs'] %}
 			<div class='card text-center mb-2 breakinpage'>
 				<div class='card-header'>
   					<h5>Scaffold insertions</h5>
@@ -336,12 +336,12 @@
       							<h5>Modification lengths for {{amplicon_name}}</h5>
 								{% endif %}
   								<ul class="nav nav-tabs justify-content-center card-header-tabs" id="aln-tab" role="tablist">
-									{% if report_data['figures']['locs'][amplicon_name]['plot_3a'] %}
+									{% if 'plot_3a' in report_data['figures']['locs'][amplicon_name] %}
   						  			<li class="nav-item">
 						  				<button class="nav-link active" data-bs-toggle="tab" data-bs-target="#{{amplicon_name}}_3a" role="tab" aria-controls="{{amplicon_name}}_3a" aria-selected="true">Summary</button>
   						  			</li>
             								{% endif %}
-									{% if report_data['figures']['locs'][amplicon_name]['plot_3b'] %}
+									{% if 'plot_3b' in report_data['figures']['locs'][amplicon_name] %}
   						  			<li class="nav-item">
 						  				<button class="nav-link" data-bs-toggle="tab" data-bs-target="#{{amplicon_name}}_3b" role="tab" aria-controls="{{amplicon_name}}_3b" aria-selected="false">Indels</button>
   						  			</li>
@@ -350,13 +350,13 @@
   							</div>
   							<div class='card-body'>
 								<div class="tab-content" id="pills-tabContent">
-									{% if report_data['figures']['locs'][amplicon_name]['plot_3a'] %}
+									{% if 'plot_3a' in report_data['figures']['locs'][amplicon_name] %}
   						  			<div class="tab-pane fade show active" id="{{amplicon_name}}_3a" role="tabpanel">
 							  			{{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_3a', amplicon_name=amplicon_name)}}
 						  			</div>
 									{% endif %}
 
-									{% if report_data['figures']['locs'][amplicon_name]['plot_3b'] %}
+									{% if 'plot_3b' in report_data['figures']['locs'][amplicon_name] %}
   						  			<div class="tab-pane fade" id="{{amplicon_name}}_3b" role="tabpanel">
 							  			{{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_3b', amplicon_name=amplicon_name)}}
 						  			</div>
@@ -373,32 +373,32 @@
   								<h5>Indel characterization for {{amplicon_name}}</h5>
 								{% endif %}
   								<ul class="nav nav-tabs justify-content-center card-header-tabs" id="indel-characterization-tabs" role="tablist">
-									{% if report_data['figures']['locs'][amplicon_name]['plot_4a'] %}
+									{% if 'plot_4a' in report_data['figures']['locs'][amplicon_name] %}
   						  			<li class="nav-item">
 						  				<button class="nav-link" data-bs-toggle="tab" data-bs-target="#{{amplicon_name}}_4a" role="tab" aria-controls="{{amplicon_name}}_4a" aria-selected="true">All Modifications Combined</button>
   						  			</li>
             								{% endif %}
-									{% if report_data['figures']['locs'][amplicon_name]['plot_4b'] %}
+									{% if 'plot_4b' in report_data['figures']['locs'][amplicon_name] %}
   						  			<li class="nav-item">
 						  				<button class="nav-link active" data-bs-toggle="tab" data-bs-target="#{{amplicon_name}}_4b" role="tab" aria-controls="{{amplicon_name}}_4b" aria-selected="false">All Modifications by Type</button>
   						  			</li>
             								{% endif %}
-									{% if report_data['figures']['locs'][amplicon_name]['plot_4c'] %}
+									{% if 'plot_4c' in report_data['figures']['locs'][amplicon_name] %}
   						  			<li class="nav-item">
 						  				<button class="nav-link" data-bs-toggle="tab" data-bs-target="#{{amplicon_name}}_4c" role="tab" aria-controls="{{amplicon_name}}_4c" aria-selected="false">Modifications in Quantification Window</button>
   						  			</li>
             								{% endif %}
-									{% if report_data['figures']['locs'][amplicon_name]['plot_4d'] %}
+									{% if 'plot_4d' in report_data['figures']['locs'][amplicon_name] %}
   						  			<li class="nav-item">
 						  				<button class="nav-link" data-bs-toggle="tab" data-bs-target="#{{amplicon_name}}_4d" role="tab" aria-controls="{{amplicon_name}}_4d" aria-selected="false">Indel Lengths</button>
   						  			</li>
             								{% endif %}
-									{% if report_data['figures']['locs'][amplicon_name]['plot_4e'] %}
+									{% if 'plot_4e' in report_data['figures']['locs'][amplicon_name] %}
   						  			<li class="nav-item">
 						  				<button class="nav-link" data-bs-toggle="tab" data-bs-target="#{{amplicon_name}}_4e" role="tab" aria-controls="{{amplicon_name}}_4e" aria-selected="false">All reads aligned to {{amplicon_name}}</button>
   						  			</li>
 								 	{% endif %}
-									{% if report_data['figures']['locs'][amplicon_name]['plot_4f'] %}
+									{% if 'plot_4f' in report_data['figures']['locs'][amplicon_name] %}
   						  			<li class="nav-item">
 						  				<button class="nav-link" data-bs-toggle="tab" data-bs-target="#{{amplicon_name}}_4f" role="tab" aria-controls="{{amplicon_name}}_4f" aria-selected="false">HDR reads aligned to {{amplicon_name}}</button>
   						  			</li>
@@ -407,35 +407,35 @@
   							</div> {# end card head #}
   							<div class='card-body'>
   								<div class="tab-content" id="pills-tabContent">
-									{% if report_data['figures']['locs'][amplicon_name]['plot_4a'] %}
+									{% if 'plot_4a' in report_data['figures']['locs'][amplicon_name] %}
 									<div class="tab-pane fade" id="{{amplicon_name}}_4a" role="tabpanel">
 										{{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_4a', amplicon_name=amplicon_name)}}
 									</div>
 									{% endif %}
-									{% if report_data['figures']['locs'][amplicon_name]['plot_4b'] %}
+									{% if 'plot_4b' in report_data['figures']['locs'][amplicon_name] %}
 									<div class="tab-pane fade show active" id="{{amplicon_name}}_4b" role="tabpanel">
 										{{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_4b', amplicon_name=amplicon_name)}}
 									</div>
 									{% endif %}
-									{% if report_data['figures']['locs'][amplicon_name]['plot_4c'] %}
+									{% if 'plot_4c' in report_data['figures']['locs'][amplicon_name] %}
 									<div class="tab-pane fade" id="{{amplicon_name}}_4c" role="tabpanel">
 										{{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_4c', amplicon_name=amplicon_name)}}
 									</div>
 									{% endif %}
 
-									{% if report_data['figures']['locs'][amplicon_name]['plot_4d'] %}
+									{% if 'plot_4d' in report_data['figures']['locs'][amplicon_name] %}
 									<div class="tab-pane fade" id="{{amplicon_name}}_4d" role="tabpanel">
 										{{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_4d', amplicon_name=amplicon_name)}}
 									</div>
 									{% endif %}
 
-									{% if report_data['figures']['locs'][amplicon_name]['plot_4e'] %}
+									{% if 'plot_4e' in report_data['figures']['locs'][amplicon_name] %}
 									<div class="tab-pane fade" id="{{amplicon_name}}_4e" role="tabpanel">
 										{{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_4e', amplicon_name=amplicon_name)}}
 									</div>
 									{% endif %}
 
-									{% if report_data['figures']['locs'][amplicon_name]['plot_4f'] %}
+									{% if 'plot_4f' in report_data['figures']['locs'][amplicon_name] %}
 									<div class="tab-pane fade" id="{{amplicon_name}}_4f" role="tabpanel">
 										{{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_4f', amplicon_name=amplicon_name)}}
 									</div>
@@ -445,7 +445,7 @@
   						</div> {# end card #}
 
 
-						{% if report_data['figures']['locs'][amplicon_name]['plot_5'] %}
+						{% if 'plot_5' in report_data['figures']['locs'][amplicon_name] %}
 						<div class='card text-center mb-2 breakinpage'>
 							<div class='card-header'>
 								{% if report_data.amplicons|length == 1 %} {# if only one amplicon #}
@@ -460,7 +460,7 @@
 						</div>
 						{% endif %}
 
-						{% if report_data['figures']['locs'][amplicon_name]['plot_6'] %}
+						{% if 'plot_6' in report_data['figures']['locs'][amplicon_name] %}
 						<div class='card text-center mb-2 breakinpage'>
 							<div class='card-header'>
 								{% if report_data.amplicons|length == 1 %} {# if only one amplicon #}
@@ -475,7 +475,7 @@
 						</div>
 						{% endif %}
 
-						{% if report_data['figures']['locs'][amplicon_name]['plot_7'] %}
+						{% if 'plot_7' in report_data['figures']['locs'][amplicon_name] %}
 						<div class='card text-center mb-2 breakinpage'>
 							<div class='card-header'>
 								{% if report_data.amplicons|length == 1 %} {# if only one amplicon #}
@@ -490,7 +490,7 @@
 						</div>
 						{% endif %}
 
-						{% if report_data['figures']['locs'][amplicon_name]['plot_8'] %}
+						{% if 'plot_8' in report_data['figures']['locs'][amplicon_name] %}
 						<div class='card text-center mb-2 breakinpage'>
 							<div class='card-header'>
 								{% if report_data.amplicons|length == 1 %} {# if only one amplicon #}
@@ -505,7 +505,7 @@
 						</div>
 						{% endif %}
 
-						{% if report_data['figures']['sgRNA_based_names'][amplicon_name] and  report_data['figures']['sgRNA_based_names'][amplicon_name]['9']%}
+						{% if amplicon_name in report_data['figures']['sgRNA_based_names'] and  '9' in report_data['figures']['sgRNA_based_names'][amplicon_name] and report_data['figures']['sgRNA_based_names'][amplicon_name]['9']|length > 0 %}
 						<div class='card text-center mb-2 breakinpage'>
 							<div class='card-header'>
 								{% if report_data.amplicons|length == 1 %} {# if only one amplicon #}
@@ -524,7 +524,7 @@
 						</div>
 						{% endif %}
 
-						{% if report_data['figures']['locs'][amplicon_name]['plot_10a'] %}
+						{% if 'plot_10a' in report_data['figures']['locs'][amplicon_name]%}
   						<div class='card text-center mb-2 breakinpage'>
   							<div class='card-header'>
 								{% if report_data.amplicons|length == 1 %} {# if only one amplicon #}
@@ -533,22 +533,22 @@
   								<h5>Base editing for {{amplicon_name}}</h5>
 								{% endif %}
   								<ul class="nav nav-tabs justify-content-center card-header-tabs" id="aln-tab" role="tablist">
-									{% if report_data['figures']['locs'][amplicon_name]['plot_10a'] %}
+									{% if 'plot_10a' in report_data['figures']['locs'][amplicon_name] %}
   						  			<li class="nav-item">
 						  				<button class="nav-link active" data-bs-toggle="tab" data-bs-target="#{{amplicon_name}}_10a" role="tab" aria-controls="{{amplicon_name}}_10a" aria-selected="true">Substitution Frequencies</button>
   						  			</li>
 									{% endif %}
-									{% if report_data['figures']['sgRNA_based_names'][amplicon_name] and report_data['figures']['sgRNA_based_names'][amplicon_name]['10d']%}
+									{% if amplicon_name in report_data['figures']['sgRNA_based_names'] and '10d' in report_data['figures']['sgRNA_based_names'][amplicon_name] %}
   						  			<li class="nav-item">
 						  				<button class="nav-link" data-bs-toggle="tab" data-bs-target="#{{amplicon_name}}_10d" role="tab" aria-controls="{{amplicon_name}}_10d" aria-selected="false">Nucleotide Frequencies</button>
   						  			</li>
 									{% endif %}
-									{% if report_data['figures']['sgRNA_based_names'][amplicon_name] and report_data['figures']['sgRNA_based_names'][amplicon_name]['10e']%}
+									{% if amplicon_name in report_data['figures']['sgRNA_based_names'] and '10e' in report_data['figures']['sgRNA_based_names'][amplicon_name] %}
   						  			<li class="nav-item">
 						  				<button class="nav-link" data-bs-toggle="tab" data-bs-target="#{{amplicon_name}}_10e" role="tab" aria-controls="{{amplicon_name}}_10e" aria-selected="false">Base Proportions</button>
   						  			</li>
             						{% endif %}
-									{% if report_data['figures']['sgRNA_based_names'][amplicon_name] and report_data['figures']['sgRNA_based_names'][amplicon_name]['10f']%}
+									{% if amplicon_name in report_data['figures']['sgRNA_based_names'] and '10f' in report_data['figures']['sgRNA_based_names'][amplicon_name] %}
   						  			<li class="nav-item">
 						  				<button class="nav-link" data-bs-toggle="tab" data-bs-target="#{{amplicon_name}}_10f" role="tab" aria-controls="{{amplicon_name}}_10f" aria-selected="false">Non-reference Bases</button>
   						  			</li>
@@ -564,14 +564,14 @@
 										<div class="mb-3">
 											{{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_10b', amplicon_name=amplicon_name)}}
                                         </div>
-                                        {% if report_data['figures']['locs'][amplicon_name]['plot_10c'] %}
+                                        {% if 'plot_10c' in report_data['figures']['locs'][amplicon_name] %}
                                         <div class="mb-3">
 											{{ render_partial('shared/partials/fig_reports.html', report_data=report_data, fig_name='plot_10c', amplicon_name=amplicon_name)}}
 										</div>
                                         {% endif %}
 									</div>
 
-									{% if report_data['figures']['sgRNA_based_names'][amplicon_name] and report_data['figures']['sgRNA_based_names'][amplicon_name]['10d']%}
+									{% if amplicon_name in report_data['figures']['sgRNA_based_names'] and '10d' in report_data['figures']['sgRNA_based_names'][amplicon_name] %}
 									<div class="tab-pane fade" id="{{amplicon_name}}_10d" role="tabpanel">
 										{% for fig_name in report_data['figures']['sgRNA_based_names'][amplicon_name]['10d'] %}
 										<div class='mb-4'>
@@ -580,7 +580,7 @@
 										{% endfor %}
 									</div>
 									{% endif %}
-									{% if report_data['figures']['sgRNA_based_names'][amplicon_name] and report_data['figures']['sgRNA_based_names'][amplicon_name]['10e']%}
+									{% if amplicon_name in report_data['figures']['sgRNA_based_names'] and '10e' in report_data['figures']['sgRNA_based_names'][amplicon_name]%}
 					  				<div class="tab-pane fade" id="{{amplicon_name}}_10e" role="tabpanel">
 						  				{% for fig_name in report_data['figures']['sgRNA_based_names'][amplicon_name]['10e'] %}
 										<div class='mb-4'>
@@ -589,7 +589,7 @@
 										{% endfor %}
               						</div>
 									{% endif %}
-									{% if report_data['figures']['sgRNA_based_names'][amplicon_name] and report_data['figures']['sgRNA_based_names'][amplicon_name]['10f']%}
+									{% if amplicon_name in report_data['figures']['sgRNA_based_names'] and '10f' in report_data['figures']['sgRNA_based_names'][amplicon_name] %}
 									<div class="tab-pane fade" id="{{amplicon_name}}_10f" role="tabpanel">
 										{% for fig_name in report_data['figures']['sgRNA_based_names'][amplicon_name]['10f'] %}
                   						<div class='mb-4'>
@@ -697,7 +697,7 @@ try {
 }
 
 	{% for amplicon_name in report_data.amplicons %}
-		{% if report_data['figures']['locs'][amplicon_name]['plot_2a'] %}
+		{% if 'plot_2a' in report_data['figures']['locs'][amplicon_name] %}
 		view = document.getElementById('zoomview_nucs_{{amplicon_name}}');
 		img = document.getElementById('tozoom_nucs_{{amplicon_name}}');
 		lens = document.getElementById('zoomlens_nucs_{{amplicon_name}}')

--- a/CRISPResso2/CRISPRessoWGSCORE.py
+++ b/CRISPResso2/CRISPRessoWGSCORE.py
@@ -744,7 +744,7 @@ def main():
                 report_name = _jp("CRISPResso2WGS_report.html")
             else:
                 report_name = OUTPUT_DIRECTORY+'.html'
-            CRISPRessoReport.make_wgs_report_from_folder(report_name, crispresso2_info, OUTPUT_DIRECTORY, _ROOT)
+            CRISPRessoReport.make_wgs_report_from_folder(report_name, crispresso2_info, OUTPUT_DIRECTORY, _ROOT, logger)
             crispresso2_info['running_info']['report_location'] = report_name
             crispresso2_info['running_info']['report_filename'] = os.path.basename(report_name)
 


### PR DESCRIPTION
* Replace Jinja2 PackageLoader with FileSystemLoader

The PackageLoader doesn't work with a fairly recent version of Jinja2 (3.0.1) and Python 3.9. Replacing with FileSystemLoader work with the older version and the latest version.

* Fix undefined variable `amplicon_name` in report template

* Refactor logging Jinja2 undefined variable warnings

* Revert plot_11a update

* Update intedration test branch

* Update jinja to warn on undefined but not fail. Fix all undefined warnings

* Fix github integration tests ref

* One more undefined variable

---------