### PR TITLE
Fix issues with `file_prefix`

### DIFF
--- a/CRISPResso2/CRISPRessoAggregateCORE.py
+++ b/CRISPResso2/CRISPRessoAggregateCORE.py
@@ -71,7 +71,7 @@ ___________________________________
 
         parser.add_argument('--debug', help='Show debug messages', action='store_true')
         parser.add_argument('-v', '--verbosity', type=int, help='Verbosity level of output to the console (1-4), 4 is the most verbose', default=3)
-        
+
         # CRISPRessoPro params
         parser.add_argument('--use_matplotlib', action='store_true',
                         help='Use matplotlib for plotting instead of plotly/d3 when CRISPRessoPro is installed')
@@ -98,7 +98,7 @@ ___________________________________
 
         log_filename=_jp('CRISPRessoAggregate_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPRessoAggregate_status.json')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(os.path.join(OUTPUT_DIRECTORY, 'CRISPRessoAggregate_status.json')))
 
         with open(log_filename, 'w+') as outfile:
               outfile.write('[Command used]:\n%s\n\n[Execution log]:\n' % ' '.join(sys.argv))

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -1288,7 +1288,7 @@ def main():
             with open(log_filename, 'w+') as outfile:
                 outfile.write('CRISPResso version %s\n[Command used]:\n%s\n\n[Execution log]:\n' %(CRISPRessoShared.__version__, crispresso_cmd_to_write))
 
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPResso_status.json')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(os.path.join(OUTPUT_DIRECTORY, 'CRISPResso_status.json')))
 
         aln_matrix_loc = os.path.join(_ROOT, "EDNAFULL")
         CRISPRessoShared.check_file(aln_matrix_loc)

--- a/CRISPResso2/CRISPRessoMetaCORE.py
+++ b/CRISPResso2/CRISPRessoMetaCORE.py
@@ -233,7 +233,7 @@ def main():
 
         log_filename=_jp('CRISPRessoMeta_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPRessoMeta_status.json')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(os.path.join(OUTPUT_DIRECTORY, 'CRISPRessoMeta_status.json')))
 
         with open(log_filename, 'w+') as outfile:
             outfile.write('[Command used]:\n%s\n\n[Execution log]:\n' % ' '.join(sys.argv))

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -327,7 +327,7 @@ def main():
 
         log_filename = _jp('CRISPRessoPooled_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPRessoPooled_status.json')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(os.path.join(OUTPUT_DIRECTORY, 'CRISPRessoPooled_status.json')))
 
         if args.zip_output and not args.place_report_in_output_folder:
             logger.warn('Invalid arguement combination: If zip_output is True then place_report_in_output_folder must also be True. Setting place_report_in_output_folder to True.')

--- a/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
+++ b/CRISPResso2/CRISPRessoPooledWGSCompareCORE.py
@@ -231,7 +231,7 @@ increase the memory required to run CRISPResso. Can be set to 'max'.
 
         log_filename = _jp('CRISPRessoPooledWGSCompare_RUNNING_LOG.txt')
         logger.addHandler(logging.FileHandler(log_filename))
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPRessoPooledWGSCompare_status.json')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(os.path.join(OUTPUT_DIRECTORY, 'CRISPRessoPooledWGSCompare_status.json')))
 
         with open(log_filename, 'w+') as outfile:
             outfile.write(

--- a/CRISPResso2/CRISPRessoReports/templates/batchReport.html
+++ b/CRISPResso2/CRISPRessoReports/templates/batchReport.html
@@ -77,11 +77,7 @@
               <div class='card-body'>
                 {% for plot_name in window_nuc_pct_quilts %}
                   <h5>{{report_data['titles'][plot_name]}}</h5>
-                  {% if plot_name in report_data['htmls'] %}
-                    {{ report_data['htmls'][plot_name]|safe }}
-                  {% else %}
-                    {{ render_partial('shared/partials/fig_summaries.html', report_data=report_data, plot_name=plot_name) }}
-                  {% endif %}
+                  {{ render_partial('shared/partials/fig_summaries.html', report_data=report_data, plot_name=plot_name) }}
                 {% endfor %}
               </div>
             </div>
@@ -95,11 +91,7 @@
               <div class='card-body'>
                 {% for plot_name in nuc_pct_quilts %}
                   <h5>{{report_data['titles'][plot_name]}}</h5>
-                  {% if plot_name in report_data['htmls'] %}
-                    {{ report_data['htmls'][plot_name]|safe }}
-                  {% else %}
-                    {{ render_partial('shared/partials/fig_summaries.html', report_data=report_data, plot_name=plot_name) }}
-                  {% endif %}
+                  {{ render_partial('shared/partials/fig_summaries.html', report_data=report_data, plot_name=plot_name) }}
                 {% endfor %}
               </div>
             </div>

--- a/CRISPResso2/CRISPRessoReports/templates/shared/partials/fig_summaries.html
+++ b/CRISPResso2/CRISPRessoReports/templates/shared/partials/fig_summaries.html
@@ -12,4 +12,5 @@
     {% for (data_label,data_path) in report_data['datas'][plot_name] %}
         <p class="m-0"><small>Data: <a href="{{report_data['crispresso_data_path']}}{{data_path}}">{{data_label}}</a></small></p>
     {% endfor %}
+    <br>
 </div>

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -1856,9 +1856,11 @@ def check_custom_config(args):
                 custom_config['colors'] = config['colors']
 
             return custom_config
-        except Exception as e:
-            logger.warn("Cannot read json file '%s', defaulting config parameters." % args.config_file)
-            print(e)
+        except Exception:
+            if args.config_file:
+                logger.warn("Cannot read config file '%s', defaulting config parameters." % args.config_file)
+            else:
+                logger.warn("No config file provided, defaulting config parameters.")
     return config
 
 

--- a/CRISPResso2/CRISPRessoWGSCORE.py
+++ b/CRISPResso2/CRISPRessoWGSCORE.py
@@ -347,7 +347,7 @@ def main():
         except:
             warn('Folder %s already exists.' % OUTPUT_DIRECTORY)
 
-        logger.addHandler(CRISPRessoShared.StatusHandler(_jp('CRISPRessoWGS_status.json')))
+        logger.addHandler(CRISPRessoShared.StatusHandler(os.path.join(OUTPUT_DIRECTORY, 'CRISPRessoWGS_status.json')))
 
         info('Checking dependencies...')
 

--- a/tests/unit_tests/test_CRISPRessoCompareCORE.py
+++ b/tests/unit_tests/test_CRISPRessoCompareCORE.py
@@ -1,0 +1,85 @@
+"""Unit tests for CRISPRessoCompareCORE."""
+
+from CRISPResso2 import CRISPRessoCompareCORE
+
+from copy import deepcopy
+import pytest
+
+
+@pytest.fixture(scope='function')
+def run_info():
+    return {
+        'results': {
+            'refs': {
+                'Reference': {
+                    'sequence':'CGGATGTTCCAATCAGTACGCAGAGAGTCGCCGTCTCCAAGGTGAAAGCGGAAGTAGGGCCTTCGCGCACCTCATGGAATCCCTTCTGCAGCACCTGGATCGCTTTTCCGAGCTTCTGGCGGTCTCAAGCACTACCTACGTCAGCACCTGGGACCCCGCCACCGTGCGCCGGGCCTTGCAGTGGGCGCGCTACCTGCGCCACATCCATCGGCGCTTTGGTCGG',
+                    'sgRNA_orig_sequences': ['GGCCCTTAAAA'],
+                    'sgRNA_cut_points': [50],
+                    'allele_frequency_files': ['Alleles_frequency_table_around_sgRNA_GGCCCTTAAAA.txt'],
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture(scope='function')
+def run_info_1(run_info):
+    return deepcopy(run_info)
+
+
+@pytest.fixture(scope='function')
+def run_info_2(run_info):
+    return deepcopy(run_info)
+
+
+def test_get_matching_allele_files(run_info):
+    matching_allele_files = CRISPRessoCompareCORE.get_matching_allele_files(run_info, run_info)
+    assert matching_allele_files == [('Alleles_frequency_table_around_sgRNA_GGCCCTTAAAA.txt', 'Alleles_frequency_table_around_sgRNA_GGCCCTTAAAA.txt')]
+
+
+def test_get_matching_allele_files_different_cut_points(run_info_1, run_info_2):
+    run_info_2['results']['refs']['Reference']['sgRNA_cut_points'] = [50, 51]
+    matching_allele_files = CRISPRessoCompareCORE.get_matching_allele_files(run_info_1, run_info_2)
+    assert matching_allele_files == []
+
+
+def test_get_matching_allele_files_different_guides(run_info_1, run_info_2):
+    run_info_2['results']['refs']['Reference']['sgRNA_orig_sequences'] = ['GGCCCTTAAAC']
+    run_info_2['results']['refs']['Reference']['allele_frequency_files'] = ['Alleles_frequency_table_around_sgRNA_GGCCCTTAAAC.txt']
+    matching_allele_files = CRISPRessoCompareCORE.get_matching_allele_files(run_info_1, run_info_2)
+    assert matching_allele_files == []
+
+
+def test_get_matching_allele_files_multiple_alleles(run_info_1, run_info_2):
+    run_info_1['results']['refs']['Other_Amplicon'] = deepcopy(run_info_1['results']['refs']['Reference'])
+    run_info_1['results']['refs']['Other_Amplicon']['sequence'] = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    run_info_1['results']['refs']['Other_Amplicon']['allele_frequency_files'] = ['Other_Amplicon.Alleles_frequency_table_around_sgRNA_GGCCCTTAAAA.txt']
+    matching_allele_files = CRISPRessoCompareCORE.get_matching_allele_files(run_info_1, run_info_2)
+    assert matching_allele_files == [('Alleles_frequency_table_around_sgRNA_GGCCCTTAAAA.txt', 'Alleles_frequency_table_around_sgRNA_GGCCCTTAAAA.txt')]
+
+
+def test_get_matching_allele_files_different_amplicon_names_same_sequence(run_info_1, run_info_2):
+    run_info_2['results']['refs']['Other_Amplicon'] = deepcopy(run_info_1['results']['refs']['Reference'])
+    del run_info_2['results']['refs']['Reference']
+    matching_allele_files = CRISPRessoCompareCORE.get_matching_allele_files(run_info_1, run_info_2)
+    assert matching_allele_files == [('Alleles_frequency_table_around_sgRNA_GGCCCTTAAAA.txt', 'Alleles_frequency_table_around_sgRNA_GGCCCTTAAAA.txt')]
+
+
+def test_get_matching_allele_files_some_different_guides(run_info_1, run_info_2):
+    run_info_1['results']['refs']['Reference']['sgRNA_orig_sequences'] += ['AAAAAAAAAAAAAAAAAAA']
+    run_info_1['results']['refs']['Reference']['allele_frequency_files'] += ['Alleles_frequency_table_around_sgRNA_AAAAAAAAAAAAAAAAAAA.txt']
+    matching_allele_files = CRISPRessoCompareCORE.get_matching_allele_files(run_info_1, run_info_2)
+    assert matching_allele_files == [('Alleles_frequency_table_around_sgRNA_GGCCCTTAAAA.txt', 'Alleles_frequency_table_around_sgRNA_GGCCCTTAAAA.txt')]
+
+
+def test_get_matching_allele_files_multiple_guides(run_info_1, run_info_2):
+    run_info_1['results']['refs']['Reference']['sgRNA_orig_sequences'] += ['AAAAAAAAAAAAAAAAAAA']
+    run_info_1['results']['refs']['Reference']['allele_frequency_files'] += ['Alleles_frequency_table_around_sgRNA_AAAAAAAAAAAAAAAAAAA.txt']
+    run_info_2['results']['refs']['Reference']['sgRNA_orig_sequences'] += ['AAAAAAAAAAAAAAAAAAA']
+    run_info_2['results']['refs']['Reference']['allele_frequency_files'] += ['Alleles_frequency_table_around_sgRNA_AAAAAAAAAAAAAAAAAAA.txt']
+    matching_allele_files = CRISPRessoCompareCORE.get_matching_allele_files(run_info_1, run_info_2)
+    assert matching_allele_files == [
+        ('Alleles_frequency_table_around_sgRNA_GGCCCTTAAAA.txt', 'Alleles_frequency_table_around_sgRNA_GGCCCTTAAAA.txt'),
+        ('Alleles_frequency_table_around_sgRNA_AAAAAAAAAAAAAAAAAAA.txt', 'Alleles_frequency_table_around_sgRNA_AAAAAAAAAAAAAAAAAAA.txt'),
+    ]
+


### PR DESCRIPTION
This PR includes:

* Update config file logging messages

This removes printing the exception (which is essentially a duplicate), and adds a condition if no config file was provided. Also changes `json` to `config` so that it is more clear.

* Fix divide by zero when no amplicons are present in Batch mode

* Don't append file_prefix to status file name

* Place status files in output directories

* Update tests branch for file_prefix addition

* Load D3 and plotly figures with pro with multiple amplicons

* Fix bug in CRISPRessoCompare with pointing to report datas with file_prefix

Before this fix, when using a file_prefix the second run that was compared would not be displayed as a data in the first figure of the report.

* Import CRISPRessoPro instead of importing the version

When installed via conda, the version is not available

* Remove `get_amplicon_output` unused function from CRISPRessoCompare

Also remove unused argparse import

* Implement `get_matching_allele_files` in CRISPRessoCompare and accompanying unit tests

This now enables CRISPRessoCompare to ensure that the amplicon sequences are the same (instead of just comparing the amplicon names) and that at least one guide matches and that the quantification windows are the same before comparing.

* Allow for matching of multiple guides in the same amplicon

* Fix pandas FutureWarning

---------