### PR TITLE
exclude UNMAP,SECONDARY,QCFAIL,DUP,SUPPLEMENTARY

### DIFF
--- a/CRISPResso2/CRISPRessoWGSCORE.py
+++ b/CRISPResso2/CRISPRessoWGSCORE.py
@@ -217,7 +217,7 @@ def extract_reads(row):
 
         info('Extracting reads in:%s and creating .bam file: %s' % (region, row.bam_file_with_reads_in_region))
 
-        cmd=r'''samtools view -b -F 4 --reference %s %s %s > %s ''' % (row.reference_file, row.original_bam, region, row.bam_file_with_reads_in_region)
+        cmd=r'''samtools view -b -F 3844 --reference %s %s %s > %s ''' % (row.reference_file, row.original_bam, region, row.bam_file_with_reads_in_region)
         sb.call(cmd, shell=True)
 
         cmd=r'''samtools index %s ''' % (row.bam_file_with_reads_in_region)


### PR DESCRIPTION
The original code only exclude the UNMAP reads from calculating edit efficiency of on/off targets, I think we should exclude the following reads as well .
SECONDARY: this is not a primary mapping position of this read.
QCFAIL: QC failed reads should be dropped. 
DUP: duplicated reads should be dropped.
SUPPLEMENTARY: this is not the major mapping part of this read.
I think use the above reads might lead to some misleading of the calculation.