### PR TITLE
Implement new pooled mixed-mode default behavior

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -49,39 +49,49 @@ jobs:
 
     - name: Run Basic
       run: |
-        make basic test
+        make basic test print
 
     - name: Run Params
       if: success() || failure()
       run: |
-        make params test
+        make params test print
 
     - name: Run Prime Editor
       if: success() || failure()
       run: |
-        make prime-editor test
+        make prime-editor test print
 
     - name: Run Batch
       if: success() || failure()
       run: |
-        make batch test
+        make batch test print
 
     - name: Run Pooled
       if: success() || failure()
       run: |
-        make pooled test
+        make pooled test print
+
+    - name: Run Pooled Mixed Mode
+      if: success() || failure()
+      run: |
+        make pooled-mixed-mode test print
+
+    - name: Run Pooled Mixed Mode Demux
+      if: success() || failure()
+      run: |
+        make pooled-mixed-mode-genome-demux test print
 
     - name: Run Pooled Paired Sim
       if: success() || failure()
       run: |
-        make pooled-paired-sim test
+        make pooled-paired-sim test print
 
     - name: Run WGS
       if: success() || failure()
       run: |
-        make wgs test
+        make wgs test print
 
     - name: Run Compare
       if: success() || failure()
       run: |
-        make compare test
+        make compare test print

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -385,7 +385,7 @@ def main():
             info('Only the bowtie2 reference genome index file was provided. The analysis will be performed using only genomic regions where enough reads align.')
         elif args.bowtie2_index and args.amplicons_file:
             RUNNING_MODE='AMPLICONS_AND_GENOME'
-            info('Amplicon description file and bowtie2 reference genome index files provided. Analysis will be performed using reads that are aligned to the amplicons and other genomic regions.')
+            info('Amplicon description file and bowtie2 reference genome index files provided. The analysis will be performed using the reads that are aligned only to the amplicons provided and not to other genomic regions.')
         else:
             error('Please provide the amplicons description file (-f or --amplicons_file option) or the bowtie2 reference genome index file (-x or --bowtie2_index option) or both.')
             sys.exit(1)

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -385,7 +385,7 @@ def main():
             info('Only the bowtie2 reference genome index file was provided. The analysis will be performed using only genomic regions where enough reads align.')
         elif args.bowtie2_index and args.amplicons_file:
             RUNNING_MODE='AMPLICONS_AND_GENOME'
-            info('Amplicon description file and bowtie2 reference genome index files provided. The analysis will be performed using the reads that are aligned only to the amplicons provided and not to other genomic regions.')
+            info('Amplicon description file and bowtie2 reference genome index files provided. Analysis will be performed using reads that are aligned to the amplicons and other genomic regions.')
         else:
             error('Please provide the amplicons description file (-f or --amplicons_file option) or the bowtie2 reference genome index file (-x or --bowtie2_index option) or both.')
             sys.exit(1)
@@ -1032,7 +1032,7 @@ def main():
                 os.mkdir(MAPPED_REGIONS)
 
                 # if we should only demultiplex where amplicons aligned... (as opposed to the whole genome)
-                if RUNNING_MODE=='AMPLICONS_AND_GENOME' and args.demultiplex_only_at_amplicons:
+                if RUNNING_MODE=='AMPLICONS_AND_GENOME' and not args.demultiplex_genome_wide:
                     s1 = r'''samtools view -F 0x0004 %s __REGIONCHR__:__REGIONSTART__-__REGIONEND__ 2>>%s |''' % (bam_filename_genome, log_filename)+\
                     r'''awk 'BEGIN{OFS="\t";num_records=0;fastq_filename="__OUTPUTPATH__REGION___REGIONCHR_____REGIONSTART_____REGIONEND__.fastq";} \
                         { \

--- a/CRISPResso2/args.json
+++ b/CRISPResso2/args.json
@@ -18,7 +18,7 @@
             "name": "Amplicon Sequence",
             "keys": ["-a", "--amplicon_seq"],
             "help": "Amplicon Sequence (can be comma-separated list of multiple sequences)",
-            "type": "str", 
+            "type": "str",
             "tools": ["Core", "Batch", "Pooled"]
         },
         "amplicon_name": {
@@ -757,7 +757,13 @@
         },
         "demultiplex_only_at_amplicons": {
             "keys": ["--demultiplex_only_at_amplicons"],
-            "help": "If set, and an amplicon file (--amplicons_file) and reference sequence (--bowtie2_index) are provided, reads overlapping alignment positions of amplicons will be demultiplexed and assigned to that amplicon. If this flag is not set, the entire genome will be demultiplexed and reads with the same start and stop coordinates as an amplicon will be assigned to that amplicon.",
+            "help": "DEPRECATED in v2.3.2, see `demultiplex_at_amplicons_and_genome`",
+            "action": "store_true",
+            "tools": ["Pooled"]
+        },
+        "demultiplex_genome_wide": {
+            "keys": ["--demultiplex_genome_wide"],
+            "help": "If set, and an amplicon file (--amplicons_file) and reference sequence (--bowtie2_index) are provided, the entire genome will be demultiplexed and reads with the exact same start and stop coordinates as an amplicon will be assigned to that amplicon. If this flag is not set, reads overlapping alignment positions of amplicons will be demultiplexed and assigned to that amplicon.",
             "action": "store_true",
             "tools": ["Pooled"]
         },


### PR DESCRIPTION
Now by default, when Pooled is run in mixed-mode (an amplicon file and genome are both provided) CRISPResso will demultiplex the reads that align to the locations in the genomes. This means that reads don't need to align perfectly to the same start and end coordinates. To restore the previous default behavior, one can provide the `--demultiplex_genome_wide` parameter.