### PR TITLE
Fix Compare divide by zero

### DIFF
--- a/CRISPResso2/CRISPRessoBatchCORE.py
+++ b/CRISPResso2/CRISPRessoBatchCORE.py
@@ -610,8 +610,8 @@ def main():
                         if not args.suppress_plots and not args.suppress_batch_summary_plots and should_plot_large_plots(sub_nucleotide_percentage_summary_df.shape[0], C2PRO_INSTALLED, args.use_matplotlib):
                             # plot for each guide
                             # show all sgRNA's on the plot
-                            sub_sgRNA_intervals = []
-                            for sgRNA_interval in consensus_sgRNA_intervals:
+                            sub_sgRNA_intervals, sub_consensus_guides = [], []
+                            for sgRNA_index, sgRNA_interval in enumerate(consensus_sgRNA_intervals):
                                 newstart = None
                                 newend = None
                                 for idx, i in enumerate(sgRNA_plot_idxs):
@@ -633,6 +633,10 @@ def main():
                                     newend = len(include_idxs) - 1
                                 # and add it to the list
                                 sub_sgRNA_intervals.append((newstart, newend))
+                                sub_consensus_guides.append(consensus_guides[sgRNA_index])
+
+                            # scale the include_idxs to be in terms of the plot centered around the sgRNA
+                            sub_include_idxs = include_idxs - sgRNA_plot_idxs[0]
 
                             this_window_nuc_pct_quilt_plot_name = _jp(amplicon_plot_name.replace('.', '') + 'Nucleotide_percentage_quilt_around_sgRNA_'+sgRNA)
                             nucleotide_quilt_input = {
@@ -641,8 +645,8 @@ def main():
                                 'fig_filename_root': f'{this_window_nuc_pct_quilt_plot_name}.json' if not args.use_matplotlib and C2PRO_INSTALLED else this_window_nuc_pct_quilt_plot_name,
                                 'save_also_png': save_png,
                                 'sgRNA_intervals': sub_sgRNA_intervals,
-                                'sgRNA_sequences': consensus_guides,
-                                'quantification_window_idxs': include_idxs,
+                                'sgRNA_sequences': sub_consensus_guides,
+                                'quantification_window_idxs': sub_include_idxs,
                                 'custom_colors': custom_config['colors'],
                             }
                             debug('Plotting nucleotide percentage quilt for amplicon {0}, sgRNA {1}'.format(amplicon_name, sgRNA))
@@ -665,7 +669,7 @@ def main():
                                     'conversion_nuc_to': args.conversion_nuc_to,
                                     'save_also_png': save_png,
                                     'sgRNA_intervals': sub_sgRNA_intervals,
-                                    'quantification_window_idxs': include_idxs,
+                                    'quantification_window_idxs': sub_include_idxs,
                                     'custom_colors': custom_config['colors']
                                 }
                                 debug('Plotting nucleotide conversion map for amplicon {0}, sgRNA {1}'.format(amplicon_name, sgRNA))
@@ -754,7 +758,7 @@ def main():
                         crispresso2_info['results']['general_plots']['summary_plot_labels'][plot_name] = 'Composition of each base for the amplicon ' + amplicon_name
                         crispresso2_info['results']['general_plots']['summary_plot_datas'][plot_name] = [('Nucleotide frequencies', os.path.basename(nucleotide_frequency_summary_filename)), ('Modification frequencies', os.path.basename(modification_frequency_summary_filename))]
                         if args.base_editor_output and should_plot_large_plots(nucleotide_percentage_summary_df.shape[0], False, args.use_matplotlib):
-                            this_nuc_conv_plot_name = _jp(amplicon_plot_name + 'Nucleotide_percentage_quilt')
+                            this_nuc_conv_plot_name = _jp(amplicon_plot_name + 'Nucleotide_conversion_map')
                             conversion_map_input = {
                                 'nuc_pct_df': nucleotide_percentage_summary_df,
                                 'fig_filename_root': this_nuc_conv_plot_name,
@@ -807,6 +811,7 @@ def main():
                             'plot_path': plot_path,
                             'title': modification_type,
                             'div_id': heatmap_div_id,
+                            'amplicon_name': amplicon_name,
                         }
                         debug('Plotting allele modification heatmap for {0}'.format(amplicon_name))
                         plot(
@@ -841,6 +846,7 @@ def main():
                             'plot_path': plot_path,
                             'title': modification_type,
                             'div_id': line_div_id,
+                            'amplicon_name': amplicon_name,
                         }
                         debug('Plotting allele modification line plot for {0}'.format(amplicon_name))
                         plot(

--- a/CRISPResso2/CRISPRessoCompareCORE.py
+++ b/CRISPResso2/CRISPRessoCompareCORE.py
@@ -195,7 +195,8 @@ def main():
         sig_counts = {}  # number of bp significantly modified (bonferonni corrected fisher pvalue)
         sig_counts_quant_window = {}
         percent_complete_start, percent_complete_end = 10, 90
-        percent_complete_step = (percent_complete_end - percent_complete_start) / len(amplicon_names_in_both)
+        if amplicon_names_in_both:
+            percent_complete_step = (percent_complete_end - percent_complete_start) / len(amplicon_names_in_both)
         for amplicon_name in amplicon_names_in_both:
             percent_complete = percent_complete_start + percent_complete_step * amplicon_names_in_both.index(amplicon_name)
             info('Loading data for amplicon %s' % amplicon_name, {'percent_complete': percent_complete})

--- a/CRISPResso2/CRISPRessoReports/templates/batchReport.html
+++ b/CRISPResso2/CRISPRessoReports/templates/batchReport.html
@@ -72,7 +72,7 @@
           {% if window_nuc_pct_quilts|length > 0 %}
             <div class='card text-center mb-2'>
               <div class='card-header'>
-                <h5>Nucleotide percentages around guides</h5>
+                <h5 id="nucleotide-header">Nucleotide percentages around guides</h5>
               </div>
               <div class='card-body'>
                 {% for plot_name in window_nuc_pct_quilts %}
@@ -86,11 +86,11 @@
           {% if nuc_pct_quilts|length > 0 %}
             <div class='card text-center mb-2'>
               <div class='card-header'>
-                <h5>Nucleotide percentages in the entire amplicon</h5>
+                <h5 id="nucleotide-header-full-amplicon">Nucleotide percentages in the entire amplicon</h5>
               </div>
               <div class='card-body'>
                 {% for plot_name in nuc_pct_quilts %}
-                  <h5>{{report_data['titles'][plot_name]}}</h5>
+                  <h5>{{report_data['titles'][plot_name] if plot_name in report_data['titles'] else ''}}</h5>
                   {{ render_partial('shared/partials/fig_summaries.html', report_data=report_data, plot_name=plot_name) }}
                 {% endfor %}
               </div>
@@ -104,7 +104,7 @@
               </div>
               <div class='card-body'>
                 {% for plot_name in window_nuc_conv_plots %}
-                    <h5>{{report_data['titles'][plot_name]}}</h5>
+                    <h5>{{report_data['titles'][plot_name] if plot_name in report_data['titles'] else ''}}</h5>
 		            {{ render_partial('shared/partials/fig_summaries.html', report_data=report_data, plot_name=plot_name) }}
                 {% endfor %}
               </div>
@@ -118,7 +118,7 @@
               </div>
               <div class='card-body'>
                 {% for plot_name in nuc_conv_plots %}
-                    <h5>{{report_data['titles'][plot_name]}}</h5>
+                    <h5>{{report_data['titles'][plot_name] if plot_name in report_data['titles'] else ''}}</h5>
 		            {{ render_partial('shared/partials/fig_summaries.html', report_data=report_data, plot_name=plot_name) }}
                 {% endfor %}
               </div>
@@ -129,7 +129,7 @@
             {% for plot_name in report_data['names'] %}
             <div class='card text-center mb-2'>
               <div class='card-header'>
-                <h5>{{report_data['titles'][plot_name]}}</h5>
+                <h5>{{report_data['titles'][plot_name] if plot_name in report_data['titles'] else ''}}</h5>
               </div>
               <div class='card-body'>
 		        {{ render_partial('shared/partials/fig_summaries.html', report_data=report_data, plot_name=plot_name) }}

--- a/CRISPResso2/CRISPRessoReports/templates/report.html
+++ b/CRISPResso2/CRISPRessoReports/templates/report.html
@@ -317,7 +317,7 @@
 								{% for (data_label,data_path) in report_data['figures']['datas'][amplicon_name]['plot_2a'] %}
 									<p class="m-0"><small>Data: <a href="{{report_data['crispresso_data_path']}}{{data_path}}">{{data_label}}</a></small></p>
 								{% endfor %}
-								
+
 								{% if 'plot_2b' in report_data['figures']['htmls'][amplicon_name] %}
 								  	{{ report_data['figures']['htmls'][amplicon_name]['plot_2b']|safe }}
 								{% elif report_data['figures']['sgRNA_based_names'][amplicon_name] and  report_data['figures']['sgRNA_based_names'][amplicon_name]['2b']%}
@@ -623,9 +623,11 @@
 
 {% block foot %}
 <script>
+{% if not C2PRO_INSTALLED %}
 function updateZoom(e) {
   /*prevent any other actions that may occur when moving over the image:*/
 //  e.preventDefault();
+
   var img = e.target.imgObj
   var view = e.target.viewObj
   var lens = e.target.lensObj
@@ -718,8 +720,8 @@ try {
 
 		{% endif %}
 	{% endfor %}
-	</script>
-
+{% endif %}
+</script>
 
 {% if C2PRO_INSTALLED %}
   <script src="https://unpkg.com/d3@5"></script>

--- a/CRISPResso2/CRISPRessoReports/templates/shared/partials/fig_summaries.html
+++ b/CRISPResso2/CRISPRessoReports/templates/shared/partials/fig_summaries.html
@@ -1,5 +1,5 @@
 <div id="fig_summary_{{plot_name}}">
-    {% if report_data['htmls'] and report_data['htmls'][plot_name]%}
+    {% if report_data['htmls'] and plot_name in report_data['htmls']%}
         {{report_data['htmls'][plot_name]|safe}}
     {% else %}
         {% if plot_name in ['Nucleotide_conversion_map', 'Nucleotide_percentage_quilt'] %}

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -1655,6 +1655,38 @@ def get_sgRNA_mismatch_vals(seq1, seq2, start_loc, end_loc, coords_l, coords_r, 
     return list(set(this_mismatches))
 
 
+def get_quant_window_ranges_from_include_idxs(include_idxs):
+    """Given a list of indexes, return the ranges that those indexes include.
+
+    Parameters
+    ----------
+    include_idxs: list
+       A list of indexes included in the quantification window, for example
+       `[20, 21, 22, 35, 36, 37]`.
+
+    Returns
+    -------
+    list
+       A list of tuples representing the ranges included in the quantification
+       window, for example `[(20, 22), (35, 37)]`. If there is a single index, it
+       will be reported as `[(20, 20)]`.
+    """
+    quant_ranges = []
+    if include_idxs is None or len(include_idxs) == 0:
+        return quant_ranges
+    start_idx = include_idxs[0]
+    last_idx = include_idxs[0]
+    for idx in include_idxs[1:]:
+        if idx == last_idx + 1:
+            last_idx = idx
+        else:
+            quant_ranges.append((start_idx, last_idx))
+            start_idx = idx
+            last_idx = idx
+    quant_ranges.append((start_idx, last_idx))
+    return quant_ranges
+
+
 ######
 # terminal functions
 ######

--- a/CRISPResso2/args.json
+++ b/CRISPResso2/args.json
@@ -659,7 +659,7 @@
         "skip_failed": {
             "keys": ["--skip_failed"],
             "help": "Continue with batch analysis even if one sample fails",
-            "action":"store_true",
+            "action": "store_true",
             "tools": ["Batch", "Pooled", "WGS"]
         },
         "min_reads_for_inclusion": {

--- a/tests/unit_tests/test_CRISPRessoShared.py
+++ b/tests/unit_tests/test_CRISPRessoShared.py
@@ -20,7 +20,7 @@ def test_get_mismatches():
         -5,
         -3,
     )
-    assert len(mismatch_cords) == 6 
+    assert len(mismatch_cords) == 6
 
 def test_get_relative_coordinates():
     s1inds_gap_left, s1inds_gap_right = CRISPRessoShared.get_relative_coordinates('ATCGT', 'TTCGT')
@@ -74,3 +74,27 @@ def test_get_relative_coordinates_ind_and_dels():
     assert s1inds_gap_left == [0, 2, 2, 2, 3]
     assert s1inds_gap_right == [0, 2, 3, 3, 3]
 
+
+def test_get_quant_window_ranges_from_include_idxs():
+    include_idxs = [0, 1, 2, 10, 11, 12]
+    assert CRISPRessoShared.get_quant_window_ranges_from_include_idxs(include_idxs) == [(0, 2), (10, 12)]
+
+
+def test_get_quant_window_ranges_from_include_idxs_empty():
+    include_idxs = []
+    assert CRISPRessoShared.get_quant_window_ranges_from_include_idxs(include_idxs) == []
+
+
+def test_get_quant_window_ranges_from_include_idxs_single():
+    include_idxs = [50, 51, 52, 53]
+    assert CRISPRessoShared.get_quant_window_ranges_from_include_idxs(include_idxs) == [(50, 53)]
+
+
+def test_get_quant_window_ranges_from_include_idxs_single_gap():
+    include_idxs = [50, 51, 52, 53, 55]
+    assert CRISPRessoShared.get_quant_window_ranges_from_include_idxs(include_idxs) == [(50, 53), (55, 55)]
+
+
+def test_get_quant_window_ranges_from_include_idxs_multiple_gaps():
+    include_idxs = [50, 51, 52, 53, 55, 56, 57, 58, 60]
+    assert CRISPRessoShared.get_quant_window_ranges_from_include_idxs(include_idxs) == [(50, 53), (55, 58), (60, 60)]


### PR DESCRIPTION
When there are no shared amplicon names in CRISPRessoCompare, there is a divide by zero error. This PR fixes that.