### PR TITLE
Cache read merging step in CRISPRessoPooled on no_rerun

### DIFF
--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -378,14 +378,14 @@ def main():
 
         if args.amplicons_file and not args.bowtie2_index:
             RUNNING_MODE='ONLY_AMPLICONS'
-            info('Only the Amplicon description file was provided. The analysis will be performed using only the provided amplicons sequences.')
+            info('Only the amplicon description file was provided. The analysis will be performed using only the provided amplicon sequences.')
 
         elif args.bowtie2_index and not args.amplicons_file:
             RUNNING_MODE='ONLY_GENOME'
-            info('Only the bowtie2 reference genome index file was provided. The analysis will be performed using only genomic regions where enough reads align.')
+            info('Only the bowtie2 reference genome index file was provided. The analysis will be performed using only genomic regions with sufficient read alignment depth.')
         elif args.bowtie2_index and args.amplicons_file:
             RUNNING_MODE='AMPLICONS_AND_GENOME'
-            info('Amplicon description file and bowtie2 reference genome index files provided. The analysis will be performed using the reads that are aligned only to the amplicons provided and not to other genomic regions.')
+            info('Amplicon description file and bowtie2 reference genome index files provided. The analysis will be performed using the reads that are aligned to the genome only where the provided amplicons align and not to other genomic regions.')
         else:
             error('Please provide the amplicons description file (-f or --amplicons_file option) or the bowtie2 reference genome index file (-x or --bowtie2_index option) or both.')
             sys.exit(1)

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -29,7 +29,7 @@ from inspect import getmodule, stack
 from CRISPResso2 import CRISPResso2Align
 from CRISPResso2 import CRISPRessoCOREResources
 
-__version__ = "2.3.2"
+__version__ = "2.3.1"
 
 
 ###EXCEPTIONS############################

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -29,7 +29,7 @@ from inspect import getmodule, stack
 from CRISPResso2 import CRISPResso2Align
 from CRISPResso2 import CRISPRessoCOREResources
 
-__version__ = "2.3.1"
+__version__ = "2.3.2"
 
 
 ###EXCEPTIONS############################


### PR DESCRIPTION
Previously, the --no_rerun flag would re-merge paired reads upon rerunning an incomplete CRISPRessoPooled analysis. This fix avoids this (time-consuming) pre-processing step if it has already been completed.