### PR TITLE
Replace zcat

### DIFF
--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -782,13 +782,13 @@ def get_most_frequent_reads(fastq_r1, fastq_r2, number_of_reads_to_consider, fas
 
     view_cmd_1 = 'cat'
     if fastq_r1.endswith('.gz'):
-        view_cmd_1 = 'zcat'
+        view_cmd_1 = 'gunzip -c'
     file_generation_command = "%s %s | head -n %d " % (view_cmd_1, fastq_r1, number_of_reads_to_consider * 4)
 
     if fastq_r2:
         view_cmd_2 = 'cat'
         if fastq_r2.endswith('.gz'):
-            view_cmd_2 = 'zcat'
+            view_cmd_2 = 'gunzip -c'
         min_overlap_param = ""
         if min_paired_end_reads_overlap:
             min_overlap_param = "--overlap_len_require {0}".format(min_paired_end_reads_overlap)


### PR DESCRIPTION
Replace `zcat` with `gunzip -c` in `get_most_frequent_reads` as `gunzip -c` is more reliable on most systems.

