### PR TITLE
Read Alignment Parallelization (#98)

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -41,8 +41,7 @@ jobs:
           CACHE_NUMBER: 0
         with:
           path: /usr/share/miniconda/envs/test_env
-          key:
-            conda-${{ runner.os }}--${{ runner.arch }}--${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('.github/envs/test_env.yml') }}
+          key: conda-${{ runner.os }}--${{ runner.arch }}--${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('.github/envs/test_env.yml') }}
 
       - name: Update Conda Env
         run: |
@@ -79,6 +78,21 @@ jobs:
         if: success() || failure()
         run: |
           make prime-editor test print
+
+      - name: Run BAM Input
+        if: success() || failure()
+        run: |
+          make bam test print
+
+      - name: Run BAM Output
+        if: success() || failure()
+        run: |
+          make bam-out test print
+
+      - name: Run BAM Genome Output
+        if: success() || failure()
+        run: |
+          make bam-out-genome test print
 
       - name: Run Batch
         if: success() || failure()

--- a/tests/unit_tests/test_CRISPRessoCORE.py
+++ b/tests/unit_tests/test_CRISPRessoCORE.py
@@ -192,6 +192,80 @@ def test_get_cloned_include_idxs_from_quant_window_coordinates_include_zero():
     quant_window_coordinates = '0-5'
     s1inds = [0, 1, 2, 3, 4, 5]
     assert CRISPRessoCORE.get_cloned_include_idxs_from_quant_window_coordinates(quant_window_coordinates, s1inds) == [0, 1, 2, 3, 4, 5]
+
+
+# Testing parallelization functions
+def test_regular_input():
+    # Test with typical input
+    assert CRISPRessoCORE.get_variant_cache_equal_boundaries(100, 4) == [0, 25, 50, 75, 100]
+
+def test_remainder_input():
+#     # Test with typical input
+    assert CRISPRessoCORE.get_variant_cache_equal_boundaries(101, 4) == [0, 25, 50, 75, 101]
+
+def test_similar_num_reads_input():
+#     # Test with typical input
+    assert CRISPRessoCORE.get_variant_cache_equal_boundaries(11, 10) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11]
+
+def test_large_similar_num_reads_input():
+#     # Test with typical input
+    assert CRISPRessoCORE.get_variant_cache_equal_boundaries(101, 100) == list(range(0, 100)) + [101]
+
+def test_more_processes_than_reads():
+#     # Test with typical input
+    # assert CRISPRessoCORE.get_variant_cache_equal_boundaries(3, 5) 
+    # assert that an exception is raised
+    with pytest.raises(Exception):
+        CRISPRessoCORE.get_variant_cache_equal_boundaries(3, 5)
+
+def test_single_process():
+    # Test with a single process
+    assert CRISPRessoCORE.get_variant_cache_equal_boundaries(50, 1) == [0, 50]
+
+def test_zero_sequences():
+    # Test with zero unique sequences
+    with pytest.raises(Exception):
+        CRISPRessoCORE.get_variant_cache_equal_boundaries(0, 3)
+
+def test_large_numbers():
+    # Test with large number of processes and sequences
+    boundaries = CRISPRessoCORE.get_variant_cache_equal_boundaries(10000, 10)
+    assert len(boundaries) == 11  # Check that there are 11 boundaries
+
+def test_sublist_generation():
+    n_processes = 4
+    unique_reads = 100
+    mock_variant_cache = [i for i in range(unique_reads)]
+    assert len(mock_variant_cache) == 100
+    boundaries = CRISPRessoCORE.get_variant_cache_equal_boundaries(unique_reads, n_processes) 
+    assert boundaries == [0, 25, 50, 75, 100]
+    sublists = []
+    for i in range(n_processes):
+        left_sublist_index = boundaries[i]
+        right_sublist_index = boundaries[i+1]
+        sublist = mock_variant_cache[left_sublist_index:right_sublist_index]
+        sublists.append(sublist)
+    assert [len(sublist) for sublist in sublists] == [25, 25, 25, 25]
+    assert [s for sublist in sublists for s in sublist] == mock_variant_cache
+
+def test_irregular_sublist_generation():
+    n_processes = 4
+    unique_reads = 113
+    mock_variant_cache = [i for i in range(unique_reads)]
+    assert len(mock_variant_cache) == 113
+    boundaries = CRISPRessoCORE.get_variant_cache_equal_boundaries(unique_reads, n_processes) 
+    # assert boundaries == [0, 25, 50, 75, 100]
+    sublists = []
+    for i in range(n_processes):
+        left_sublist_index = boundaries[i]
+        right_sublist_index = boundaries[i+1]
+        sublist = mock_variant_cache[left_sublist_index:right_sublist_index]
+        sublists.append(sublist)
+    assert [len(sublist) for sublist in sublists] == [28,28,28,29]
+    assert [s for sublist in sublists for s in sublist] == mock_variant_cache
+
+
+
     
 if __name__ == "__main__":
 # execute only if run as a script


### PR DESCRIPTION
This PR parallelizes the generation of variant objects while aligning reads from .fastq and .bam files, resulting in more than 8.5x speed increase for runs (One benchmark showed an improvement in run time from 1:23:28 down to 0:09:45 [H:MM:SS])

It refactors the four functions that read from user's input files (process_fastq, process_bam, process_fastq_write_out, and process_single_fastq_write_bam_out). It reads over the files, identifies and counts each unique DNA read, then sends the unique reads in equal chunks to n sub processes for parallel processing, where n is the number of cores specified by the user.

These processes each then stores generated variants in intermediate .tsv files, which are later read to track statistics of the files. If specified, these functions also write out annotated bam or fastq files.