### PR TITLE
Add flexiguide alignment parameters

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,7 +2,7 @@ name: Run Pytest
 
 on:
   push:
-  
+
   pull_request:
     types: [opened, reopened]
 
@@ -20,9 +20,8 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
-          mamba-version: "*"
           channels: conda-forge,bioconda,defaults
           auto-activate-base: false
           activate-environment: test_env
@@ -32,15 +31,15 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc g++ bowtie2 samtools libsys-hostname-long-perl
-        
+
     - name: Install Pytest
       run: |
         pip install pytest pytest-cov
-    
+
     - name: Install CRISPResso
       run: |
         pip install -e .
 
     - name: Run Pytest
-      run: | 
+      run: |
         pytest tests --cov CRISPResso2

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -2022,14 +2022,14 @@ def main():
                     #for all amps in forward and reverse complement amps:
                     for amp_seq in [this_seq, CRISPRessoShared.reverse_complement(this_seq)]:
                         ref_incentive = np.zeros(len(amp_seq)+1, dtype=int)
-                        s1, s2, score=CRISPResso2Align.global_align(guide, amp_seq, matrix=aln_matrix, gap_incentive=ref_incentive, gap_open=args.needleman_wunsch_gap_open, gap_extend=args.needleman_wunsch_gap_extend,)
+                        s1, s2, score=CRISPResso2Align.global_align(guide, amp_seq, matrix=aln_matrix, gap_incentive=ref_incentive, gap_open=args.flexiguide_gap_open_penalty, gap_extend=args.flexiguide_gap_extend_penalty)
                         potential_guide = s1.strip("-")
                         if abs(len(potential_guide) - len(guide)) < 2: #if length of putative guide is off by less than 2, keep it (allows 1 gap)
                             loc = s1.find(potential_guide)
                             potential_ref = amp_seq[loc:loc+len(potential_guide)]
                             #realign to test for number of mismatches
                             ref_incentive = np.zeros(len(potential_ref)+1, dtype=int)
-                            sub_s1, sub_s2, sub_score=CRISPResso2Align.global_align(guide, potential_ref, matrix=aln_matrix, gap_incentive=ref_incentive, gap_open=args.needleman_wunsch_gap_open, gap_extend=args.needleman_wunsch_gap_extend,)
+                            sub_s1, sub_s2, sub_score=CRISPResso2Align.global_align(guide, potential_ref, matrix=aln_matrix, gap_incentive=ref_incentive, gap_open=args.flexiguide_gap_open_penalty, gap_extend=args.flexiguide_gap_extend_penalty)
                             mismatches = []
                             for i in range(len(sub_s1)):
                                 if sub_s1[i] != sub_s2[i]:

--- a/CRISPResso2/args.json
+++ b/CRISPResso2/args.json
@@ -91,6 +91,20 @@
             "default": "",
             "tools": ["Core", "Batch", "Pooled", "WGS"]
         },
+        "flexiguide_gap_open_penalty": {
+            "keys": ["--flexiguide_gap_open_penalty"],
+            "help": "",
+            "type": "int",
+            "default": -20,
+            "tools": ["Core", "Batch", "Pooled", "WGS"]
+        },
+        "flexiguide_gap_extend_penalty": {
+            "keys": ["--flexiguide_gap_extend_penalty"],
+            "help": "",
+            "type": "int",
+            "default": -2,
+            "tools": ["Core", "Batch", "Pooled", "WGS"]
+        },
         "discard_guide_positions_overhanging_amplicon_edge": {
             "keys": ["--discard_guide_positions_overhanging_amplicon_edge"],
             "help": "If set, for guides that align to multiple positions, guide positions will be discarded if plotting around those regions would included bp that extend beyond the end of the amplicon.",


### PR DESCRIPTION
* Add flexiguid gap open and gap extend customized arguments

* Implement new flexiguide gap extend and gap open parameters

* Point to new test branch for integration tests

* Bump version of setup-miniconda for pytest

* Have flexiguide default penalties match the Needleman Wunsch defaults

* Point test branch back to master