### PR TITLE
Mckay/halt on plot fail

### DIFF
--- a/CRISPResso2/CRISPRessoAggregateCORE.py
+++ b/CRISPResso2/CRISPRessoAggregateCORE.py
@@ -71,6 +71,7 @@ ___________________________________
 
         parser.add_argument('--debug', help='Show debug messages', action='store_true')
         parser.add_argument('-v', '--verbosity', type=int, help='Verbosity level of output to the console (1-4), 4 is the most verbose', default=3)
+        parser.add_argument('--halt_on_plot_fail', action="store_true", help="Halt execution if a plot fails to generate")
 
         # CRISPRessoPro params
         parser.add_argument('--use_matplotlib', action='store_true',
@@ -131,6 +132,7 @@ ___________________________________
             num_processes=n_processes,
             process_pool=process_pool,
             process_futures=process_futures,
+            halt_on_plot_fail=args.halt_on_plot_fail,
         )
 
         #glob returns paths including the original prefix

--- a/CRISPResso2/CRISPRessoBatchCORE.py
+++ b/CRISPResso2/CRISPRessoBatchCORE.py
@@ -400,6 +400,7 @@ def main():
             num_processes=n_processes_for_batch,
             process_futures=process_futures,
             process_pool=process_pool,
+            halt_on_plot_fail=args.halt_on_plot_fail,
         )
 
         window_nuc_pct_quilt_plot_names = []

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -3746,6 +3746,7 @@ def main():
             num_processes=n_processes,
             process_pool=process_pool,
             process_futures=process_futures,
+            halt_on_plot_fail=args.halt_on_plot_fail,
         )
         ###############################################################################################################################################
         ### FIGURE 1: Alignment
@@ -5174,6 +5175,10 @@ def main():
         print_stacktrace_if_debug()
         error('Filtering error, please check your input.\n\nERROR: %s' % e)
         sys.exit(13)
+    except CRISPRessoShared.PlotException as e:
+        print_stacktrace_if_debug()
+        error(e)
+        sys.exit(14)
     except Exception as e:
         print_stacktrace_if_debug()
         error('Unexpected error, please check your input.\n\nERROR: %s' % e)

--- a/CRISPResso2/CRISPRessoMultiProcessing.py
+++ b/CRISPResso2/CRISPRessoMultiProcessing.py
@@ -16,6 +16,9 @@ import numpy as np
 import pandas as pd
 import traceback
 
+from CRISPResso2.CRISPRessoShared import PlotException
+
+
 def get_max_processes():
     return mp.cpu_count()
 
@@ -284,7 +287,7 @@ def run_parallel_commands(commands_arr, n_processes=1, descriptor='CRISPResso2',
     pool.join()
 
 
-def run_plot(plot_func, plot_args, num_processes, process_futures, process_pool):
+def run_plot(plot_func, plot_args, num_processes, process_futures, process_pool, halt_on_plot_fail):
     """Run a plot in parallel if num_processes > 1, otherwise in serial.
 
     Parameters
@@ -299,6 +302,8 @@ def run_plot(plot_func, plot_args, num_processes, process_futures, process_pool)
         The list of futures that submitting the parallel job will return.
     process_pool: ProcessPoolExecutor or ThreadPoolExecutor
         The pool to submit the job to.
+    halt_on_plot_fail: bool
+        If True, an exception will be raised if the plot fails
 
     Returns
     -------
@@ -311,5 +316,8 @@ def run_plot(plot_func, plot_args, num_processes, process_futures, process_pool)
         else:
             plot_func(**plot_args)
     except Exception as e:
+        if halt_on_plot_fail:
+            logger.critical(f"Plot error, halting execution \n")
+            raise PlotException(f'There was an error generating plot {plot_func.__name__}.')
         logger.warn(f"Plot error {e}, skipping plot \n")
         logger.debug(traceback.format_exc())

--- a/CRISPResso2/CRISPRessoPlot.py
+++ b/CRISPResso2/CRISPRessoPlot.py
@@ -2668,7 +2668,6 @@ def prep_alleles_table(df_alleles, reference_seq, MAX_N_ROWS, MIN_FREQUENCY):
     """
     dna_to_numbers={'-':0,'A':1,'T':2,'C':3,'G':4,'N':5}
     seq_to_numbers= lambda seq: [dna_to_numbers[x] for x in seq]
-
     X=[]
     annot=[]
     y_labels=[]

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -80,8 +80,14 @@ class OutputFolderIncompleteException(Exception):
 class InstallationException(Exception):
     pass
 
+
 class InputFileFormatException(Exception):
     pass
+
+
+class PlotException(Exception):
+    pass
+
 
 #########################################
 

--- a/CRISPResso2/args.json
+++ b/CRISPResso2/args.json
@@ -860,6 +860,12 @@
             "help": "Use matplotlib for plotting instead of plotly/d3 when CRISPRessoPro is installed",
             "action": "store_true",
             "tools": ["Core", "Batch", "Pooled", "WGS", "Compare"]
+        },
+        "halt_on_plot_fail": {
+            "keys": ["--halt_on_plot_fail"],
+            "help": "Halt execution if a plot fails to generate",
+            "action": "store_true",
+            "tools": ["Core", "Batch", "Pooled", "WGS", "Compare"]
         }
     },
     "Sections": {


### PR DESCRIPTION
This PR adds a new CLI argument, `--halt_on_plot_fail`, which throws an exception when there is an error in generating a plot. The default behavior when there is a plotting error is to continue running and generate a partial report with the erroneous plot missing.