### PR TITLE
Update jinja_partials and bring Reports into sync

### DIFF
--- a/CRISPResso2/CRISPRessoReports/.github/workflows/pylint.yml
+++ b/CRISPResso2/CRISPRessoReports/.github/workflows/pylint.yml
@@ -2,8 +2,9 @@ name: Pylint
 
 on:
   push:
-    branches:
-      - '*'
+
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
   build:

--- a/CRISPResso2/CRISPRessoReports/jinja_partials.py
+++ b/CRISPResso2/CRISPRessoReports/jinja_partials.py
@@ -28,6 +28,11 @@ from functools import partial
 
 from markupsafe import Markup
 
+try:
+    import flask
+except ImportError:
+    flask = None
+
 
 def render_partial(template_name, renderer=None, markup=True, **data):
     """
@@ -36,8 +41,7 @@ def render_partial(template_name, renderer=None, markup=True, **data):
     if renderer is None:
         if flask is None:
             raise PartialsException('No renderer specified')
-        else:
-            renderer = flask.render_template
+        renderer = flask.render_template
 
     if markup:
         return Markup(renderer(template_name, **data))


### PR DESCRIPTION
This updates some linting errors in `jinja_partials` and makes it so that pylint runs in CRISPRessoReports when a PR is opened.