### PR TITLE
Add customizable samtools exclude flag

### DIFF
--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -819,9 +819,9 @@ def process_bam(bam_filename, bam_chr_loc, output_bam, variantCache, ref_names, 
         crispresso_cmd_to_write = ' '.join(sys.argv)
         sam_out.write('@PG\tID:crispresso2\tPN:crispresso2\tVN:'+CRISPRessoShared.__version__+'\tCL:"'+crispresso_cmd_to_write+'"\n')
         if bam_chr_loc != "":
-            proc = sb.Popen(['samtools', 'view', bam_filename, bam_chr_loc], stdout=sb.PIPE, encoding='utf-8')
+            proc = sb.Popen(['samtools', 'view', '-F', args.samtools_exclude_flags, bam_filename, bam_chr_loc], stdout=sb.PIPE, encoding='utf-8')
         else:
-            proc = sb.Popen(['samtools', 'view', bam_filename], stdout=sb.PIPE, encoding='utf-8')
+            proc = sb.Popen(['samtools', 'view', '-F', args.samtools_exclude_flags, bam_filename], stdout=sb.PIPE, encoding='utf-8')
         num_reads = 0
 
         # Reading through the bam file and enriching variantCache as a dictionary with the following:

--- a/CRISPResso2/args.json
+++ b/CRISPResso2/args.json
@@ -255,6 +255,20 @@
             "default": "None",
             "tools": ["Core", "Batch", "Pooled", "WGS"]
         },
+        "samtools_exclude_flags": {
+            "keys": ["--samtools_exclude_flags"],
+          "help": "Exclude reads with any of the specified flags set in the SAM/BAM file. Flags can be specified in either base 16 (hex) or base 10. Default is 4 (read unmapped).",
+            "type": "str",
+            "default": "4",
+            "tools": ["Pooled", "WGS"]
+        },
+        "samtools_exclude_flags_core": {
+            "keys": ["--samtools_exclude_flags"],
+            "help": "Exclude reads with any of the specified flags set in the SAM/BAM file. Flags can be specified in either base 16 (hex) or base 10. Default is 0 (no reads filtered).",
+            "type": "str",
+            "default": "0",
+            "tools": ["Core"]
+        },
         "stringent_flash_merging": {
             "keys": ["--stringent_flash_merging"],
             "help": "DEPRECATED in v2.3.0",

--- a/tests/unit_tests/test_CRISPRessoPooledCORE.py
+++ b/tests/unit_tests/test_CRISPRessoPooledCORE.py
@@ -1,0 +1,17 @@
+from CRISPResso2 import CRISPRessoPooledCORE
+
+
+def test_calculate_aligned_samtools_exclude_flags():
+    assert CRISPRessoPooledCORE.calculate_aligned_samtools_exclude_flags('0') == hex(0x900)
+
+
+def test_calculate_aligned_samtools_exclude_flags_4():
+    assert CRISPRessoPooledCORE.calculate_aligned_samtools_exclude_flags('4') == hex(0x904)
+
+
+def test_calculate_aligned_samtools_exclude_flags_9():
+    assert CRISPRessoPooledCORE.calculate_aligned_samtools_exclude_flags('9') == hex(0x909)
+
+
+def test_calculate_aligned_samtools_exclude_flags_0x100():
+    assert CRISPRessoPooledCORE.calculate_aligned_samtools_exclude_flags('0x100') == hex(0x900)


### PR DESCRIPTION
* Add customizable samtools exclude flag

This adds a new parameter, `--samtools_exclude_flags` that allows one to customize which reads are excluded from CRISPRessoWGS and CRISPRessoPooled runs.