### PR TITLE
Pooled multi region map fix

### DIFF
--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -1266,7 +1266,6 @@ def main():
                     demux_key = row['chr_id'] + ' ' + str(row['bpstart']) + ' ' + str(row['bpend'])
                     if demux_key in df_all_demux.index:
                         demux_row = df_all_demux.loc[demux_key]
-                        print('demux row: ' + str(demux_row))
                         N_READS = demux_row['number of reads']
                         n_reads_aligned_genome.append(N_READS)
                         fastq_filename_region = str(demux_row['output filename'])
@@ -1276,10 +1275,7 @@ def main():
                             if fastq_filename_region in files_to_match:
                                 files_to_match.remove(fastq_filename_region)
                         fastq_region_filenames.append(fastq_filename_region)
-                        #else:
-                             #info('Warning: Fastq filename ' + fastq_filename_region + ' is not in ' + str(files_to_match))
-                             #debug here??
-                        print('N_READS: "', str(N_READS) + '" fastq_file_name_region: ' + str(fastq_filename_region))
+
                         if N_READS >= args.min_reads_to_use_region and fastq_filename_region != "":
                             info('\nThe amplicon [%s] has enough reads (%d) mapped to it! Running CRISPResso!\n' % (idx, N_READS))
 

--- a/CRISPResso2/CRISPRessoPooledCORE.py
+++ b/CRISPResso2/CRISPRessoPooledCORE.py
@@ -735,6 +735,13 @@ def main():
                 duplicated_entries = df_template.amplicon_seq[df_template.amplicon_seq.duplicated()]
                 raise Exception('The amplicon sequences must be distinct! (Duplicated entries: ' + str(duplicated_entries.values) + ')')
 
+            #check to see that no sequences and their reverse complements are present
+            amp_seqs = df_template.amplicon_seq.values #Beware, this is a numpy array of dtype str and if you add these arrays amp_seqs + rc_amp_seqs, it will concat the strings, not the arrays....
+            rc_amp_seqs = [CRISPRessoShared.reverse_complement(amp_seq) for amp_seq in amp_seqs]
+            for seq in amp_seqs:
+                if seq in rc_amp_seqs:
+                    raise Exception('Amplicon sequences must be distinct! The amplicon sequence %s is the reverse complement of another amplicon sequence in the region file. Please provide only one of the two sequences.' % seq)
+
             if not len(df_template.amplicon_name.unique())==df_template.shape[0]:
                 duplicated_entries = df_template.amplicon_name[df_template.amplicon_name.duplicated()]
                 raise Exception('The amplicon names must be distinct! (Duplicated names: ' + str(duplicated_entries.values) + ')')


### PR DESCRIPTION
Previously, in CRISPRessoPooled, if two input regions map to the same genomic locus the demultiplexing will create two processes that collide to write on the same file.

For example, if a forward and reverse-complement seq are given as two regions in the in the -f file, they will map to the same location in the genome. When demultiplexing with multiprocessing, the output file will be munged by two processes writing reads to the same file.

With this PR, input is checked to make sure that no amplicons and their reverse complement exist in the input region file. Additionally, just in case, a change is made to avoid munging by two processes by demultiplexing. 