### PR TITLE
Fix `get_n_fastq` function

### DIFF
--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -138,10 +138,6 @@ def get_avg_read_length_fastq(fastq_filename):
      p = sb.Popen(cmd, shell=True, stdout=sb.PIPE)
      return int(p.communicate()[0].strip())
 
-def get_n_reads_fastq(fastq_filename):
-    p = sb.Popen(('z' if fastq_filename.endswith('.gz') else '' ) +"cat < \"%s\" | wc -l" % fastq_filename, shell=True, stdout=sb.PIPE)
-    return int(float(p.communicate()[0])/4.0)
-
 def get_n_reads_bam(bam_filename,bam_chr_loc=""):
     cmd = "samtools view -c " + bam_filename + " " + bam_chr_loc
     p = sb.Popen(cmd, shell=True, stdout=sb.PIPE)
@@ -2458,7 +2454,7 @@ def main():
 
         N_READS_INPUT = 0
         if args.fastq_r1:
-            N_READS_INPUT = get_n_reads_fastq(args.fastq_r1)
+            N_READS_INPUT = CRISPRessoShared.get_n_reads_fastq(args.fastq_r1)
         elif args.bam_input:
             N_READS_INPUT = get_n_reads_bam(args.bam_input, args.bam_chr_loc)
 
@@ -2620,7 +2616,7 @@ def main():
         if args.bam_input:
             N_READS_AFTER_PREPROCESSING = N_READS_INPUT
         else:
-            N_READS_AFTER_PREPROCESSING=get_n_reads_fastq(processed_output_filename)
+            N_READS_AFTER_PREPROCESSING=CRISPRessoShared.get_n_reads_fastq(processed_output_filename)
         if N_READS_AFTER_PREPROCESSING == 0:
             raise CRISPRessoShared.NoReadsAfterQualityFilteringException('No reads in input or no reads survived the average or single bp quality filtering.')
 

--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -492,6 +492,15 @@ def assert_fastq_format(file_path, max_lines_to_check=100):
         raise InputFileFormatException('File %s is not in fastq format!' % (file_path)) from e
 
 
+def get_n_reads_fastq(fastq_filename):
+    if not os.path.exists(fastq_filename) or os.path.getsize(fastq_filename) == 0:
+        return 0
+    
+    p = sb.Popen(('z' if fastq_filename.endswith('.gz') else '' ) +"cat < %s | grep -c ." % fastq_filename, shell=True, stdout=sb.PIPE)
+    n_reads = int(float(p.communicate()[0])/4.0)
+    return n_reads
+
+
 def check_output_folder(output_folder):
     """
     Checks to see that the CRISPResso run has completed, and gathers the amplicon info for that run


### PR DESCRIPTION
This PR fixes when get_n_fastq gets an empty gzipped file, it returns 0 instead of throwing an error.

This also fixes a bug when counting reads in fastq files that have no trailing newlines. Now, the function will return the correct number of reads if there is no trailing new line, or multiple trailing new lines.