### PR TITLE
Fix issue with numpy long not being supported in cython 3.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython", "numpy"]
+requires = ["setuptools", "wheel", "cython==3.0.12", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Building the latest version of CRISPresso2 from python fails because the project.toml uses Cython 3.1.0 that no longer supports the `long` type. See: https://github.com/pinellolab/CRISPResso2/issues/535

```sh
CRITICAL @ Fri, 16 May 2025 17:02:58 (0.5% done):
         Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/CRISPResso2/CRISPRessoCORE.py", line 1429, in main
    aln_matrix = CRISPResso2Align.read_matrix(aln_matrix_loc)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "CRISPResso2/CRISPResso2Align.pyx", line 43, in CRISPResso2.CRISPResso2Align.read_matrix
  File "CRISPResso2/CRISPResso2Align.pyx", line 51, in CRISPResso2.CRISPResso2Align.read_matrix
NameError: name 'long' is not defined
 

CRITICAL @ Fri, 16 May 2025 17:02:58 (0.5% done):
         Unexpected error, please check your input.

ERROR: name 'long' is not defined 
```

This PR sticks the version of the project.toml to built it with a previous cython version.
Solution found by @rohan-mammothbio