### PR TITLE
Pooled info parsing fix

### DIFF
--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -860,10 +860,7 @@ class CRISPRessoJSONDecoder(json.JSONDecoder):
             if obj['_type'] == 'np.ndarray':
                 return np.array(obj['value'])
             if obj['_type'] == 'pd.DataFrame':
-                val = obj['value']
-                if isinstance(val, bytes):
-                    val = val.decode('utf-8')
-                return pd.read_json(io.StringIO(val), orient='split')
+                return pd.read_json(io.StringIO(obj['value']), orient='split')
             if obj['_type'] == 'datetime.datetime':
                 return datetime.datetime.fromisoformat(obj['value'])
             if obj['_type'] == 'datetime.timedelta':


### PR DESCRIPTION
Previously, trying to parse the CRISPRessoPooled info object would result in

```
from CRISPResso2 import CRISPRessoShared
crispresso_pooled_info = CRISPRessoShared.load_crispresso_info(crispresso_info_file_path='CRISPRessoPooled_on_217-0_S22/CRISPResso2Pooled_info.json')
  
'str' object has no attribute 'decode'
```

pointing to the decoder line. However, pandas should always encode this as a string, never bytes.