### PR TITLE
Update Docker and remove defaults channel (#135)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: pinellolab/crispresso2:v2.3.0
+      - image: edilytics/crispresso2:v2.3.4rc1
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -32,7 +32,7 @@ jobs:
           command: |
             rm -rf /opt/conda/bin/CRISPRess*
             rm -rf /opt/conda/lib/python*/site-packages/CRISPResso2*
-            python setup.py install
+            pip install .
 
       - save_cache:
           paths:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,14 @@
 ############################################################
 
 #FROM continuumio/miniconda3
-FROM mambaorg/micromamba:0.13.1
+FROM mambaorg/micromamba:2.3.3
 
-# File Author / Maintainer
-MAINTAINER Kendell Clement
+USER root
+
+LABEL org.opencontainers.image.authors="support@edilytics.com"
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
 RUN apt-get update && apt-get install gcc g++ bowtie2 samtools libsys-hostname-long-perl \
   -y --no-install-recommends \
   && apt-get clean \
@@ -14,12 +18,7 @@ RUN apt-get update && apt-get install gcc g++ bowtie2 samtools libsys-hostname-l
   && rm -rf /var/lib/apt/lists/* \
   && rm -rf /usr/share/man/* \
   && rm -rf /usr/share/doc/* \
-  && conda install -c defaults -c conda-forge -c bioconda -y -n base --debug fastp numpy cython jinja2 tbb=2020.2 pyparsing=2.3.1 scipy matplotlib-base pandas plotly upsetplot\
-  && conda clean --all --yes
-
-#install ms fonts
-RUN echo "deb http://httpredir.debian.org/debian buster main contrib" > /etc/apt/sources.list \
-  && echo "deb http://security.debian.org/ buster/updates main contrib" >> /etc/apt/sources.list \
+  && echo "deb http://deb.debian.org/debian trixie main contrib" > /etc/apt/sources.list.d/contrib.list \
   && echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections \
   && apt-get update \
   && apt-get install -y ttf-mscorefonts-installer \
@@ -30,15 +29,18 @@ RUN echo "deb http://httpredir.debian.org/debian buster main contrib" > /etc/apt
   && rm -rf /usr/share/doc/* \
   && rm -rf /usr/share/zoneinfo
 
+
+RUN micromamba install -c conda-forge -c bioconda -y -n base --debug fastp numpy cython jinja2 tbb=2020.2 pyparsing=2.3.1 setuptools scipy matplotlib-base seaborn pandas plotly upsetplot\
+  && micromamba clean --all --yes
+
 # install crispresso
 COPY . /CRISPResso2
 WORKDIR /CRISPResso2
-RUN python setup.py install \
+RUN pip install . \
   && CRISPResso -h \
   && CRISPRessoBatch -h \
   && CRISPRessoPooled -h \
   && CRISPRessoWGS -h \
   && CRISPRessoCompare -h
-
 
 ENTRYPOINT ["python","/CRISPResso2/CRISPResso2_router.py"]


### PR DESCRIPTION
* Remove Anaconda defaults channel from conda install

* Update version of micromamba Docker image

* Upgrade to micromamba:2.3.3, run as root, and replace MAINTAINER

* Update to install from correct source for Debian trixie and run in micromamba correctly

* Point Circle CI image to edilytics/crispresso2:v2.3.4rc1 (has upsetplot)

* Use pip install instead of setup.py in Circle CI

* Update to automatically activate the conda environment