### PR TITLE
Improved Exception handling and fixed not_aln edge case bug

### DIFF
--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -1250,7 +1250,7 @@ def process_paired_fastq(fastq1_filename, fastq2_filename, variantCache, ref_nam
                                 else:
                                     if args.debug:
                                         error(f"Could not parse variant from line: {line}")
-                                    error(f"Could not parse variant from file")
+                                    raise CRISPRessoShared.OutputFolderIncompleteException(f"Could not parse variant from file")
                                 variant_count = variantCache[seq][0]
                                 N_TOT_READS += variant_count
                                 variant = variant_dict
@@ -1769,7 +1769,7 @@ def process_fastq(fastq_filename, variantCache, ref_names, refs, args, files_to_
                                 else:
                                     if args.debug:
                                         error(f"Could not parse variant from line: {line}")
-                                    error(f"Could not parse variant from file")
+                                    raise CRISPRessoShared.OutputFolderIncompleteException(f"Could not parse variant from file")
                                 variant_count = variantCache[seq]
                                 N_TOT_READS += variant_count
                                 variant = variant_dict
@@ -1979,7 +1979,7 @@ def process_bam(bam_filename, bam_chr_loc, output_bam, variantCache, ref_names, 
                                 else:
                                     if args.debug:
                                         error(f"Could not parse variant from line: {line}")
-                                    error(f"Could not parse variant from file")
+                                    raise CRISPRessoShared.OutputFolderIncompleteException(f"Could not parse variant from file")
                                 variant_count = variantCache[seq]
                                 new_variant['count'] = variant_count
                                 N_TOT_READS += variant_count
@@ -2259,6 +2259,7 @@ def process_single_fastq_write_bam_out(fastq_input, bam_output, bam_header, vari
 
             # if the sequence has been seen and can't be aligned, skip it
             if fastq_seq in not_aln:
+                new_variant = not_aln[fastq_seq]
                 new_sam_entry = [
                     fastq_id,  # read id
                     '4',             # flag = unmapped 0x4


### PR DESCRIPTION
In bam_write_out, there was a bug where the previous variant object would be written if a read did not meet minimum homology score, which behavior would break if this describes the first variant processed. This PR fixes this behavior and also improves exception handling.