### PR TITLE
Fix a bug for `--bam_output` when there are unaligned reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 
 - Fix a `SyntaxWarning` for an unescaped sequence in a matplotlib function by [@Colelyman](https://github.com/Colelyman) in [#600](https://github.com/pinellolab/CRISPResso2/pull/600)
 
+- Fix a bug during `--bam_output` when there is an unaligned read, the remainder of the reads will not bu output by [@Colelyman](https://github.com/Colelyman) in [#602](https://github.com/pinellolab/CRISPResso2/pull/602)
+
 ### CHANGED
 
 - Update the base Docker image to `mambaorg/micromamba:2.3.3` and remove dependency on Anaconda `defaults` channel by [@Colelyman](https://github.com/Colelyman) in [#575](https://github.com/pinellolab/CRISPResso2/pull/575)

--- a/CRISPResso2/CRISPRessoCORE.py
+++ b/CRISPResso2/CRISPRessoCORE.py
@@ -2288,7 +2288,6 @@ def process_single_fastq_write_bam_out(fastq_input, bam_output, bam_header, vari
                         " ALN_DETAILS=" + ('&'.join([','.join([str(y) for y in x]) for x in new_variant['ref_aln_details']]))
                 new_sam_entry.append(crispresso_sam_optional_fields)
                 sam_out_handle.write("\t".join(new_sam_entry)+"\n")  # write cached alignment with modified read id and qual
-                continue
 
             if fastq_seq in variantCache:
                 new_variant = variantCache[fastq_seq]


### PR DESCRIPTION
This PR fixes behavior when the `--bam_output` parameter is present and there are unaligned reads in the input. Before this PR, the output BAM file would stop at the first unaligned read, but after this PR it will output the unaligned read and the remaining reads.