### PR TITLE
Fix how pixi manages environments, clean up the delination with pro and testing

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -38,11 +38,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: CRISPResso2
 
       - name: Set up Pixi
         uses: prefix-dev/setup-pixi@v0.8.8
         with:
-          environments: test
+          manifest-path: CRISPResso2/pixi.toml
+          environments: ${{ matrix.pro && 'test-pro' || 'test' }}
           locked: false
           frozen: false
           cache: false
@@ -50,8 +53,8 @@ jobs:
       - name: Cache Pixi environment
         uses: actions/cache@v4
         with:
-          path: .pixi
-          key: pixi-v2-${{ runner.os }}-${{ runner.arch }}-test-${{ hashFiles('pixi.toml') }}
+          path: CRISPResso2/.pixi
+          key: pixi-v2-${{ runner.os }}-${{ runner.arch }}-${{ matrix.pro && 'test-pro' || 'test' }}-${{ hashFiles('CRISPResso2/pixi.toml') }}
 
       - name: Install MS core fonts
         run: |
@@ -68,17 +71,10 @@ jobs:
             cp /usr/share/fonts/truetype/msttcorefonts/*.ttf .pixi/msttcorefonts/
           fi
           sudo fc-cache -f
+        working-directory: CRISPResso2
 
-      - name: Install environment
-        run: pixi install -e test
-
-      - name: Install CRISPResso
-        run: pixi run -e test install
-
-      - name: Rebuild pixi fontconfig cache and clear matplotlib font cache
-        run: |
-          pixi run -e test -- fc-cache -f
-          pixi run -e test -- python -c "import matplotlib; import shutil; shutil.rmtree(matplotlib.get_cachedir(), ignore_errors=True); print('Cleared', matplotlib.get_cachedir())"
+      - name: Select Pixi environment
+        run: echo "PIXI_ENV=${{ matrix.pro && 'test-pro' || 'test' }}" >> $GITHUB_ENV
 
       - name: Checkout CRISPResso2_tests
         uses: actions/checkout@v4
@@ -95,11 +91,26 @@ jobs:
           token: ${{ secrets.CRISPRESSOPRO_PAT }}
           path: CRISPRessoPro
 
-      - name: Install CRISPRessoPro
-        if: matrix.pro
-        run: pixi run -e test -- pip install -e CRISPRessoPro && pixi run -e test -- pip install kaleido==0.2.1
+      - name: Install environment
+        run: cd CRISPResso2 && pixi install -e $PIXI_ENV
+
+      - name: Install CRISPResso packages
+        run: |
+          cd CRISPResso2
+          if [ "$PIXI_ENV" = "test-pro" ]; then
+            pixi run -e test-pro install-pro
+          else
+            pixi run -e test install
+          fi
+
+      - name: Rebuild pixi fontconfig cache and clear matplotlib font cache
+        run: |
+          cd CRISPResso2
+          pixi run -e $PIXI_ENV -- fc-cache -f
+          pixi run -e $PIXI_ENV -- python -c "import matplotlib; import shutil; shutil.rmtree(matplotlib.get_cachedir(), ignore_errors=True); print('Cleared', matplotlib.get_cachedir())"
 
       - name: Run Tests
         run: |
-          pixi run -e test -- pytest CRISPResso2_tests/test_cli.py \
-            -m "${{ matrix.group.filter }}" -v ${{ matrix.pro && '--pro' || '' }} ${{ !matrix.pro && '--diff-plots' || '' }} --test --print
+          cd CRISPResso2
+          pixi run -e $PIXI_ENV -- pytest ../CRISPResso2_tests/test_cli.py \
+            -m "${{ matrix.group.filter }}" -v ${{ !matrix.pro && '--diff-plots' || '' }} --test --print

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,11 @@ CRISPResso2 is a bioinformatics pipeline for analyzing CRISPR/Cas9 genome editin
 
 ### Installation (Development)
 ```bash
+# Preferred (matches CI/task contract)
+pixi install -e default
+pixi run install
+
+# Alternative
 pip install -e .
 ```
 
@@ -19,6 +24,11 @@ pip install -e .
 
 Unit tests (pytest):
 ```bash
+# Preferred (explicit test lane)
+pixi install -e test
+pixi run -e test test
+
+# Direct pytest alternatives
 pytest tests/unit_tests/
 
 # With coverage
@@ -55,6 +65,18 @@ Individual integration test targets:
 - `make base_editor` - Base editing analysis
 
 Add `test` target to diff results against expected: `make basic test`
+
+CRISPRessoPro lanes:
+```bash
+# Runtime/dev lane (run Pro code)
+pixi install -e pro
+pixi run -e pro install-pro
+
+# Testing lane (Pro + test deps)
+pixi install -e test-pro
+pixi run -e test-pro install-pro
+pixi run -e test-pro pro-unit-test
+```
 
 ### Running CRISPResso Tools
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,18 +66,6 @@ Individual integration test targets:
 
 Add `test` target to diff results against expected: `make basic test`
 
-CRISPRessoPro lanes:
-```bash
-# Runtime/dev lane (run Pro code)
-pixi install -e pro
-pixi run -e pro install-pro
-
-# Testing lane (Pro + test deps)
-pixi install -e test-pro
-pixi run -e test-pro install-pro
-pixi run -e test-pro pro-unit-test
-```
-
 ### Running CRISPResso Tools
 
 ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY pixi.toml pyproject.toml ./
 RUN pixi install
 
 COPY . .
-RUN pixi run install
+RUN pixi run -e default install
 
 # --- Runtime stage: slim image with just the environment ---
 FROM ubuntu:24.04
@@ -43,10 +43,10 @@ COPY --from=build /CRISPResso2 /CRISPResso2
 WORKDIR /CRISPResso2
 
 # Verify
-RUN pixi run -- CRISPResso -h \
-  && pixi run -- CRISPRessoBatch -h \
-  && pixi run -- CRISPRessoPooled -h \
-  && pixi run -- CRISPRessoWGS -h \
-  && pixi run -- CRISPRessoCompare -h
+RUN pixi run -e default -- CRISPResso -h \
+  && pixi run -e default -- CRISPRessoBatch -h \
+  && pixi run -e default -- CRISPRessoPooled -h \
+  && pixi run -e default -- CRISPRessoWGS -h \
+  && pixi run -e default -- CRISPRessoCompare -h
 
-ENTRYPOINT ["pixi", "run", "--", "python", "/CRISPResso2/CRISPResso2_router.py"]
+ENTRYPOINT ["pixi", "run", "-e", "default", "--", "python", "/CRISPResso2/CRISPResso2_router.py"]

--- a/README.md
+++ b/README.md
@@ -33,29 +33,6 @@ CRISPResso2 can be [installed](https://docs.crispresso.com/installation.html) in
   - [Bioconda on Apple Silicon](https://docs.crispresso.com/installation.html#bioconda-for-apple-silicon)
 - [Docker](https://docs.crispresso.com/installation.html#docker)
 
-## Development (Pixi)
-
-For local development and CI parity, use explicit Pixi environments:
-
-```bash
-# Core/runtime lane (default)
-pixi install -e default
-pixi run install
-
-# CRISPResso2 unit tests
-pixi install -e test
-pixi run -e test test
-
-# CRISPRessoPro runtime/dev lane (run Pro code, not necessarily tests)
-pixi install -e pro
-pixi run -e pro install-pro
-
-# CRISPRessoPro testing lane (includes test dependencies)
-pixi install -e test-pro
-pixi run -e test-pro install-pro
-pixi run -e test-pro pro-unit-test
-```
-
 ## Examples
 
 - [CRISPResso example runs](https://docs.crispresso.com/suite/core/examples.html)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,29 @@ CRISPResso2 can be [installed](https://docs.crispresso.com/installation.html) in
   - [Bioconda on Apple Silicon](https://docs.crispresso.com/installation.html#bioconda-for-apple-silicon)
 - [Docker](https://docs.crispresso.com/installation.html#docker)
 
+## Development (Pixi)
+
+For local development and CI parity, use explicit Pixi environments:
+
+```bash
+# Core/runtime lane (default)
+pixi install -e default
+pixi run install
+
+# CRISPResso2 unit tests
+pixi install -e test
+pixi run -e test test
+
+# CRISPRessoPro runtime/dev lane (run Pro code, not necessarily tests)
+pixi install -e pro
+pixi run -e pro install-pro
+
+# CRISPRessoPro testing lane (includes test dependencies)
+pixi install -e test-pro
+pixi run -e test-pro install-pro
+pixi run -e test-pro pro-unit-test
+```
+
 ## Examples
 
 - [CRISPResso example runs](https://docs.crispresso.com/suite/core/examples.html)

--- a/pixi.toml
+++ b/pixi.toml
@@ -65,18 +65,13 @@ cmd = "make $ARGS"
 cwd = "../CRISPResso2_tests"
 depends-on = ["install"]
 
-[feature.pro.tasks.integration]
-cmd = "pytest test_cli.py"
-cwd = "../CRISPResso2_tests"
-depends-on = ["install", "install-pro"]
-
 [feature.pro.tasks]
-install = "pip install -e . && pip install -e ../CRISPRessoPro"
+install-pro = "pip install -e . && pip install -e ../CRISPRessoPro"
 
 [feature.pro.tasks.pro-unit-test]
 cmd = "pytest tests --cov CRISPRessoPro"
 cwd = "../CRISPRessoPro"
-depends-on = ["install"]
+depends-on = ["install-pro"]
 
 [feature.lint.tasks]
 lint = { cmd = "ruff check . --statistics" }


### PR DESCRIPTION
* Fix how pixi manages environments, clean up the delination with pro and testing

* Fix how pixi environment is specified

* Fix when the repos are checked out

* Move CRISPRessoPro to sibling directory