### PR TITLE
Reduce docker size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,31 @@ RUN pixi install
 COPY . .
 RUN pixi run -e default install
 
-# --- Runtime stage: slim image with just the environment ---
+# --- Prune stage: trim non-runtime artifacts before final copy ---
+FROM build AS runtime_env
+
+RUN rm -rf /CRISPResso2/.pixi/envs/default/include \
+  && rm -rf /CRISPResso2/.pixi/envs/default/conda-meta \
+  && rm -rf /CRISPResso2/.pixi/envs/default/man \
+  && rm -rf /CRISPResso2/.pixi/envs/default/share/man \
+  && rm -rf /CRISPResso2/.pixi/envs/default/share/doc \
+  && rm -rf /CRISPResso2/.pixi/envs/default/lib/cmake \
+  && find /CRISPResso2/.pixi/envs/default -type d -name '__pycache__' -prune -exec rm -rf '{}' + \
+  && find /CRISPResso2/.pixi/envs/default -type f -name '*.a' -delete \
+  && rm -rf /CRISPResso2/.pixi/envs/default/lib/python*/site-packages/pip \
+  && rm -rf /CRISPResso2/.pixi/envs/default/lib/python*/site-packages/pip-* \
+  && rm -rf /CRISPResso2/.pixi/envs/default/lib/python*/site-packages/setuptools \
+  && rm -rf /CRISPResso2/.pixi/envs/default/lib/python*/site-packages/setuptools-* \
+  && rm -rf /CRISPResso2/.pixi/envs/default/lib/python*/site-packages/wheel \
+  && rm -rf /CRISPResso2/.pixi/envs/default/lib/python*/site-packages/wheel-* \
+  && rm -rf /CRISPResso2/.pixi/envs/default/lib/python*/site-packages/Cython \
+  && rm -rf /CRISPResso2/.pixi/envs/default/lib/python*/site-packages/cython* \
+  && rm -rf /CRISPResso2/.pixi/envs/default/lib/python*/site-packages/pyximport \
+  && rm -f /CRISPResso2/.pixi/envs/default/bin/pip* \
+  && rm -f /CRISPResso2/.pixi/envs/default/bin/cython* \
+  && rm -f /CRISPResso2/.pixi/envs/default/bin/wheel
+
+# --- Runtime stage: slim image with runtime environment only ---
 FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.authors="support@edilytics.com"
@@ -34,19 +58,24 @@ RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula sele
   && rm -rf /usr/share/doc/* \
   && rm -rf /usr/share/zoneinfo
 
-# Copy pixi binary from build stage
-COPY --from=build /usr/local/bin/pixi /usr/local/bin/pixi
+# Keep env path identical to build stage to avoid shebang/entrypoint path issues.
+COPY --from=runtime_env /CRISPResso2/.pixi/envs/default /CRISPResso2/.pixi/envs/default
 
-# Copy the project (includes .pixi/ environment) from build stage
-COPY --from=build /CRISPResso2 /CRISPResso2
+# Copy only minimal app files required at runtime.
+COPY --from=runtime_env /CRISPResso2/CRISPResso2 /CRISPResso2/CRISPResso2
+COPY --from=runtime_env /CRISPResso2/CRISPResso2.egg-info /CRISPResso2/CRISPResso2.egg-info
+COPY --from=runtime_env /CRISPResso2/CRISPResso2_router.py /CRISPResso2/CRISPResso2_router.py
+COPY --from=runtime_env /CRISPResso2/LICENSE.txt /CRISPResso2/LICENSE.txt
 
 WORKDIR /CRISPResso2
 
-# Verify
-RUN pixi run -e default -- CRISPResso -h \
-  && pixi run -e default -- CRISPRessoBatch -h \
-  && pixi run -e default -- CRISPRessoPooled -h \
-  && pixi run -e default -- CRISPRessoWGS -h \
-  && pixi run -e default -- CRISPRessoCompare -h
+ENV PATH="/CRISPResso2/.pixi/envs/default/bin:${PATH}"
 
-ENTRYPOINT ["pixi", "run", "-e", "default", "--", "python", "/CRISPResso2/CRISPResso2_router.py"]
+# Verify (disable .pyc generation to avoid adding cache files in this layer)
+RUN PYTHONDONTWRITEBYTECODE=1 CRISPResso -h \
+  && PYTHONDONTWRITEBYTECODE=1 CRISPRessoBatch -h \
+  && PYTHONDONTWRITEBYTECODE=1 CRISPRessoPooled -h \
+  && PYTHONDONTWRITEBYTECODE=1 CRISPRessoWGS -h \
+  && PYTHONDONTWRITEBYTECODE=1 CRISPRessoCompare -h
+
+ENTRYPOINT ["python", "/CRISPResso2/CRISPResso2_router.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,11 +71,10 @@ WORKDIR /CRISPResso2
 
 ENV PATH="/CRISPResso2/.pixi/envs/default/bin:${PATH}"
 
-# Verify (disable .pyc generation to avoid adding cache files in this layer)
-RUN PYTHONDONTWRITEBYTECODE=1 CRISPResso -h \
-  && PYTHONDONTWRITEBYTECODE=1 CRISPRessoBatch -h \
-  && PYTHONDONTWRITEBYTECODE=1 CRISPRessoPooled -h \
-  && PYTHONDONTWRITEBYTECODE=1 CRISPRessoWGS -h \
-  && PYTHONDONTWRITEBYTECODE=1 CRISPRessoCompare -h
+RUN CRISPResso -h \
+  && CRISPRessoBatch -h \
+  && CRISPRessoPooled -h \
+  && CRISPRessoWGS -h \
+  && CRISPRessoCompare -h
 
 ENTRYPOINT ["python", "/CRISPResso2/CRISPResso2_router.py"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,20 +10,15 @@ python = ">=3.10,<3.13"
 numpy = "*"
 cython = "*"
 scipy = "*"
-matplotlib = "*"
+matplotlib-base = "*"
 seaborn = "*"
 pandas = "<3.0"
 jinja2 = "*"
 fastp = "*"
 bowtie2 = "*"
 samtools = "*"
-plotly = "==5.18.0"
 setuptools = "*"
 pip = "*"
-
-[target.linux-64.dependencies]
-gcc_linux-64 = "*"
-gxx_linux-64 = "*"
 
 [feature.test.dependencies]
 pytest = "*"
@@ -37,6 +32,7 @@ ydiff = "*"
 inline-snapshot = "*"
 
 [feature.pro.dependencies]
+plotly = "==5.18.0"
 python-kaleido = "<=0.2.1"
 
 [feature.lint.dependencies]


### PR DESCRIPTION
* Limit copying the pixi environment

* docker: prune pixi runtime env and run without pixi

* pixi: use matplotlib-base and drop default compiler deps

* pixi: move plotly from default to pro feature