### PR TITLE
Add `Aligned_Sequence` to compare output (#171)

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -81,7 +81,6 @@ jobs:
         with:
           repository: edilytics/CRISPResso2_tests
           # ref: '<BRANCH-NAME>' # update to specific branch
-          ref: cole/add-aligned-seq-to-compare-output
           path: CRISPResso2_tests
 
       - name: Checkout CRISPRessoPro

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           repository: edilytics/CRISPResso2_tests
           # ref: '<BRANCH-NAME>' # update to specific branch
+          ref: cole/add-aligned-seq-to-compare-output
           path: CRISPResso2_tests
 
       - name: Checkout CRISPRessoPro

--- a/CRISPResso2/CRISPRessoCompareCORE.py
+++ b/CRISPResso2/CRISPRessoCompareCORE.py
@@ -402,7 +402,7 @@ def main():
                 merged = merged.reset_index(drop=True).set_index('Aligned_Sequence')
                 folder_root = os.path.split(allele_file_1)[1].replace(".txt", "")
                 allele_comparison_file = _jp(folder_root + '.txt')
-                merged.to_csv(allele_comparison_file, sep="\t", index=None)
+                merged.to_csv(allele_comparison_file, sep="\t")
 
                 is_base_edit = 'base_edit' in allele_file_1
                 if is_base_edit:

--- a/pixi.toml
+++ b/pixi.toml
@@ -22,7 +22,6 @@ pip = "*"
 
 [feature.test.dependencies]
 pytest = "*"
-pytest-cov = "*"
 pytest-check = "*"
 pytest-xdist = "*"
 pillow = "*"
@@ -54,7 +53,7 @@ test-pro = { features = ["test", "pro"], solve-group = "default" }
 install = "pip install -e ."
 
 [feature.test.tasks]
-test = { cmd = "pytest tests --cov CRISPResso2", depends-on = ["install"] }
+test = { cmd = "pytest tests CRISPResso2", depends-on = ["install"] }
 
 [feature.test.tasks.integration]
 cmd = "make $ARGS"
@@ -65,7 +64,7 @@ depends-on = ["install"]
 install-pro = "pip install -e . && pip install -e ../CRISPRessoPro"
 
 [feature.pro.tasks.pro-unit-test]
-cmd = "pytest tests --cov CRISPRessoPro"
+cmd = "pytest tests CRISPRessoPro"
 cwd = "../CRISPRessoPro"
 depends-on = ["install-pro"]
 


### PR DESCRIPTION
* Add Aligned_Sequence to CRISPRessoCompare output

The index was set to None, which led to the Aligned_Sequence not being output

* Point to updated test branch

* Remove --cov from unit tests