### PR TITLE
Replace fastp `--stdout` with `--merged_out /dev/stdout`

### DIFF
--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -1053,7 +1053,7 @@ def get_most_frequent_reads(fastq_r1, fastq_r2, number_of_reads_to_consider, fas
                 num_reads=number_of_reads_to_consider * 4,
             ),
             awk="awk -v OFS=\"\\n\" -v FS=\"\\t\" '{{print($1,$3,$5,$7,$2,$4,$6,$8)}}'",
-            fastp='{fastp_command} --disable_adapter_trimming --disable_trim_poly_g --disable_quality_filtering --disable_length_filtering --stdin --interleaved_in --merge {min_overlap_param} --stdout 2>/dev/null'.format(
+            fastp='{fastp_command} --disable_adapter_trimming --disable_trim_poly_g --disable_quality_filtering --disable_length_filtering --stdin --interleaved_in --merge {min_overlap_param} --merged_out /dev/stdout 2>/dev/null'.format(
                 fastp_command=fastp_command,
                 min_overlap_param=min_overlap_param,
             ),


### PR DESCRIPTION
This fixes the auto amplicon mode, because when `--stdout` is used in fastp 1.3.3 it produces empty output.