### PR TITLE
Fix quantification window at reference end

### DIFF
--- a/CRISPResso2/CRISPRessoShared.py
+++ b/CRISPResso2/CRISPRessoShared.py
@@ -1726,7 +1726,7 @@ def get_amplicon_info_for_guides(ref_seq, guides, guide_mismatches, guide_names,
 
             if quantification_window_sizes[guide_idx] > 0:
                 st = max(0, cut_p - quantification_window_sizes[guide_idx] + 1)
-                en = min(ref_seq_length - 1, cut_p + quantification_window_sizes[guide_idx] + 1)
+                en = min(ref_seq_length, cut_p + quantification_window_sizes[guide_idx] + 1)
                 this_include_idxs.extend(range(st, en))
                 this_sgRNA_include_idxs.append(list(range(st, en)))
             else:
@@ -1758,7 +1758,7 @@ def get_amplicon_info_for_guides(ref_seq, guides, guide_mismatches, guide_names,
 
             if quantification_window_sizes[guide_idx] > 0:
                 st = max(0, cut_p - quantification_window_sizes[guide_idx] + 1)
-                en = min(ref_seq_length - 1, cut_p + quantification_window_sizes[guide_idx] + 1)
+                en = min(ref_seq_length, cut_p + quantification_window_sizes[guide_idx] + 1)
                 this_include_idxs.extend(range(st, en))
                 this_sgRNA_include_idxs.append(list(range(st, en)))
             else:

--- a/tests/unit_tests/test_CRISPRessoShared.py
+++ b/tests/unit_tests/test_CRISPRessoShared.py
@@ -275,6 +275,57 @@ def test_get_quant_window_ranges_from_include_idxs_multiple_gaps():
 
 
 # =============================================================================
+# Tests for get_amplicon_info_for_guides function
+# =============================================================================
+
+
+def test_get_amplicon_info_for_guides_fw_include_idxs_include_right_edge():
+    """A forward guide window ending at the reference edge includes the terminal base."""
+    ref_seq = "AAAAACCCCCGACGTTTTTT"
+    result = CRISPRessoShared.get_amplicon_info_for_guides(
+        ref_seq=ref_seq,
+        guides=["GACGT"],
+        guide_mismatches=[[]],
+        guide_names=[""],
+        quantification_window_centers=[0],
+        quantification_window_sizes=[5],
+        quantification_window_coordinates=None,
+        exclude_bp_from_left=0,
+        exclude_bp_from_right=0,
+        plot_window_size=10,
+        guide_plot_cut_points=[True],
+    )
+
+    sgRNA_include_idxs = list(result[7][0])
+    include_idxs = list(result[8])
+    assert sgRNA_include_idxs[-1] == len(ref_seq) - 1
+    assert include_idxs[-1] == len(ref_seq) - 1
+
+
+def test_get_amplicon_info_for_guides_rv_include_idxs_include_right_edge():
+    """A reverse-complement guide window ending at the reference edge includes the terminal base."""
+    ref_seq = "AAAAACCCCCGACGTTTTTT"
+    result = CRISPRessoShared.get_amplicon_info_for_guides(
+        ref_seq=ref_seq,
+        guides=["ACGTC"],
+        guide_mismatches=[[]],
+        guide_names=[""],
+        quantification_window_centers=[-5],
+        quantification_window_sizes=[5],
+        quantification_window_coordinates=None,
+        exclude_bp_from_left=0,
+        exclude_bp_from_right=0,
+        plot_window_size=10,
+        guide_plot_cut_points=[True],
+    )
+
+    sgRNA_include_idxs = list(result[7][0])
+    include_idxs = list(result[8])
+    assert sgRNA_include_idxs[-1] == len(ref_seq) - 1
+    assert include_idxs[-1] == len(ref_seq) - 1
+
+
+# =============================================================================
 # Tests for get_silent_edits function
 # =============================================================================
 


### PR DESCRIPTION
This PR fixes a bug where the quantification window will be off by one if it extends to the end of the sequence. This also affects the window around the sgRNA's plots downstream, and fixes when the last base isn't included. 